### PR TITLE
Rename Unshelled to SansShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# Unshelled
+# SanShell
 A non-interactive daemon for host management
 
-Unshelled is primarily gRPC server with a variety of options for localhost
+SansShell is primarily gRPC server with a variety of options for localhost
 debugging and management. Its goal is to replace the need to use an
 interactive shell for emergency debugging and recovery with a much safer
 interface. Each authorized action can be evaluated against an OPA policy,
 audited in advance or after the fact, and is ideally deterministic (for a given
 state of the local machine).
 
-unshelled-client is a simple CLI with a friendly API for dumping debugging
-state and interacting with a remote machine.  It also includes a set of
-convenient but perhaps-less-friendly subcommands to address the raw Unshelled
-API endpoints.
+sanssh is a simple CLI with a friendly API for dumping debugging state and
+interacting with a remote machine.  It also includes a set of convenient but
+perhaps-less-friendly subcommands to address the raw SansShell API endpoints.
 
 # Getting Started
 How to setup, build and run locally for testing.  All commands are relative to
@@ -37,17 +36,17 @@ $ mkdir -m 0700 certs
 $ cd certs
 $ $(go env GOPATH)/bin/generate-cert --host=localhost,127.0.0.1,::1
 $ cd ../
-$ ln -s $(pwd)/certs ~/.unshelled
+$ ln -s $(pwd)/certs ~/.sansshell
 ```
 
 Then you can build and run the server, in separate terminal windows:
 ```
-$ cd cmd/unshelled-server && go build && ./unshelled-server
-$ cd cmd/unshelled-client && go build && ./unshelled-client read /etc/hosts
+$ cd cmd/sansshell-server && go build && ./sansshell-server
+$ cd cmd/sanssh && go build && ./sanssh read /etc/hosts
 ```
 
 # A tour of the codebase
-Unshelled is composed of 4 primary concepts:
+SansShell is composed of 4 primary concepts:
    1. A series of services, which live in the =services/= directory.
    1. A server which wraps these services into a local host agent.
    1. A reference server binary, which includes all of the services.
@@ -56,8 +55,8 @@ Unshelled is composed of 4 primary concepts:
 
 ## Services
 Services implement at least one gRPC API endpoint, and expose it by calling
-=RegisterUnshelledService= from =init()=.  The goal is to allow custom
-implementations of the Unshelled Server to easily import services they wish to
+=RegisterSansShellService= from =init()=.  The goal is to allow custom
+implementations of the SansShell Server to easily import services they wish to
 use, and have zero overhead or risk from services they do not import at compile
 time.
 
@@ -69,40 +68,40 @@ time.
 TODO: Document service/.../client expectations.
 
 ## The Server class
-Most of the logic of instantiating a local Unshelled server lives in =/server=.
+Most of the logic of instantiating a local SansShell server lives in =/server=.
 This instantiates a gRPC server, registers the imported services with that
 server, and constraints them with the supplied OPA policy.
 
 ## The reference Server binary
-There is a reference implementation of an Unshelled Server in
-=cmd/unshelled-server=, which should be suitable as-written for many use cases.
+There is a reference implementation of an SansShell Server in
+=cmd/sansshell-server=, which should be suitable as-written for many use cases.
 It's intentionally kept relatively short, so that it can be copied to another
 repository and customized by adjusting only the imported services.
 
 ## The reference CLI client
-There is a reference implementation of an Unshelled CLI Client in
-=cmd/unshelled-client=.  It provides raw access to each gRPC endpoint, as well
+There is a reference implementation of an SansShell CLI Client in
+=cmd/sanssh=.  It provides raw access to each gRPC endpoint, as well
 as a way to implement "convenience" commands which chain together a series of
 actions.
 
-# Extending Unshelled
-Unshelled is built on a principle of "Don't pay for what you don't use".  This
-is advantageous in both minimizing the resources of Unshelled (binary size,
-memory footprint, etc) as well as reducing the security risk of running it.  To
-accomplish that, all of Unshelled services are independent modules, which can
-be optionally included at build time.  The reference server and client provide
-access to the features of all of the built-in modules, and come with exposure
-to all of their potential bugs and bloat.
+# Extending SansShell
+SansShell is built on a principle of "Don't pay for what you don't use".  This
+is advantageous in both minimizing the resources of SansShell server (binary
+size, memory footprint, etc) as well as reducing the security risk of running
+it.  To accomplish that, all of the SansShell services are independent modules,
+which can be optionally included at build time.  The reference server and
+client provide access to the features of all of the built-in modules, and come
+with exposure to all of their potential bugs and bloat.
 
-As a result, we expect most users of Unshelled would want to copy a very
+As a result, we expect most users of SansShell would want to copy a very
 minimal set of the code (a handful of lines from the reference client and
 server), import only the modules they intend to use, and build their own
-derivative of Unshelled with more (or less!) functionality.
+derivative of SansShell with more (or less!) functionality.
 
 That same extensibility makes it easy to add additional functionality by
 implementing your own module.
 
-TODO: Add example client and server, building in different unshelled modules.
+TODO: Add example client and server, building in different SansShell modules.
 
 If you need to edit a proto file (to augment an existing service or 
 create a new one) you'll need to generate proto outputs.

--- a/auth/mtls/client.go
+++ b/auth/mtls/client.go
@@ -9,8 +9,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// GetClientCredentials returns transport credentials for unshelled clients, based on the provided
-// `loaderName`
+// GetClientCredentials returns transport credentials for SansShell clients,
+// based on the provided `loaderName`
 func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
 	loader, err := Loader(loaderName)
 	if err != nil {
@@ -28,7 +28,7 @@ func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.
 	return NewClientCredentials(cert, pool), nil
 }
 
-// NewClientCredentials returns transport credentials for unshelled clients.
+// NewClientCredentials returns transport credentials for SansShell clients.
 func NewClientCredentials(cert tls.Certificate, CAPool *x509.CertPool) credentials.TransportCredentials {
 	return credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{cert},

--- a/auth/mtls/flags/flags.go
+++ b/auth/mtls/flags/flags.go
@@ -9,17 +9,17 @@ import (
 	"os"
 	"path"
 
-	"github.com/snowflakedb/unshelled/auth/mtls"
+	"github.com/Snowflake-Labs/sansshell/auth/mtls"
 )
 
 const (
 	loaderName = "flags"
 
-	defaultClientCertPath = ".unshelled/client.pem"
-	defaultClientKeyPath  = ".unshelled/client.key"
-	defaultServerCertPath = ".unshelled/leaf.pem"
-	defaultServerKeyPath  = ".unshelled/leaf.key"
-	defaultRootCAPath     = ".unshelled/root.pem"
+	defaultClientCertPath = ".sansshell/client.pem"
+	defaultClientKeyPath  = ".sansshell/client.key"
+	defaultServerCertPath = ".sansshell/leaf.pem"
+	defaultServerKeyPath  = ".sansshell/leaf.key"
+	defaultRootCAPath     = ".sansshell/root.pem"
 )
 
 var (

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -1,4 +1,4 @@
-// Package mtls facilitates Mutual TLS authentication for Unshelled.
+// Package mtls facilitates Mutual TLS authentication for SansShell.
 package mtls
 
 import (

--- a/auth/mtls/roundtrip_test.go
+++ b/auth/mtls/roundtrip_test.go
@@ -11,13 +11,13 @@ import (
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
-	"github.com/snowflakedb/unshelled/server"
-	hc "github.com/snowflakedb/unshelled/services/healthcheck"
+	"github.com/Snowflake-Labs/sansshell/server"
+	hc "github.com/Snowflake-Labs/sansshell/services/healthcheck"
 )
 
 const (
 	allowPolicy = `
-package unshelled.authz
+package sansshell.authz
 
 default allow = false
 
@@ -28,7 +28,7 @@ allow {
 }
 `
 	denyPolicy = `
-package unshelled.authz
+package sansshell.authz
 
 default allow = false
 

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -9,8 +9,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// GetServerCredentials returns transport credentials for an unshelled server as retrieved from the
-// specified `loaderName`
+// GetServerCredentials returns transport credentials for a SansShell server as
+// retrieved from the specified `loaderName`
 func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
 	loader, err := Loader(loaderName)
 	if err != nil {
@@ -28,7 +28,7 @@ func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.
 	return NewServerCredentials(cert, pool), nil
 }
 
-// NewServerCredentials creates transport credentials for an unshelled server.
+// NewServerCredentials creates transport credentials for a SansShell server.
 func NewServerCredentials(cert tls.Certificate, CAPool *x509.CertPool) credentials.TransportCredentials {
 	return credentials.NewTLS(&tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -1,4 +1,4 @@
-// Package main implements the unshelled cli client.
+// Package main implements the SansShell CLI client.
 package main
 
 import (
@@ -13,11 +13,11 @@ import (
 	"google.golang.org/grpc"
 
 	// Import the raw command clients you want, they automatically register
-	"github.com/snowflakedb/unshelled/auth/mtls"
-	mtlsFlags "github.com/snowflakedb/unshelled/auth/mtls/flags"
-	_ "github.com/snowflakedb/unshelled/services/exec/client"
-	_ "github.com/snowflakedb/unshelled/services/healthcheck/client"
-	_ "github.com/snowflakedb/unshelled/services/localfile/client"
+	"github.com/Snowflake-Labs/sansshell/auth/mtls"
+	mtlsFlags "github.com/Snowflake-Labs/sansshell/auth/mtls/flags"
+	_ "github.com/Snowflake-Labs/sansshell/services/exec/client"
+	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/client"
+	_ "github.com/Snowflake-Labs/sansshell/services/localfile/client"
 )
 
 var (
@@ -26,7 +26,7 @@ var (
 )
 
 func main() {
-	address := flag.String("address", defaultAddress, "Address to contact unshelled-server")
+	address := flag.String("address", defaultAddress, "Address to contact sansshell-server")
 	timeout := flag.Duration("timeout", defaultTimeout, "How long to wait for the command to complete")
 	credSource := flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 
@@ -46,7 +46,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set up a connection to the unshelled-server.
+	// Set up a connection to the sansshell-server.
 	conn, err := grpc.Dial(*address, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not connect to %q: %v\n", *address, err)

--- a/cmd/sansshell-server/default-policy.rego
+++ b/cmd/sansshell-server/default-policy.rego
@@ -1,4 +1,4 @@
-package unshelled.authz
+package sansshell.authz
 
 default allow = false
 

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -1,3 +1,4 @@
+// Package main implements the SansShell server.
 package main
 
 import (
@@ -9,15 +10,14 @@ import (
 	"log"
 	"strings"
 
-	"github.com/snowflakedb/unshelled/auth/mtls"
-	mtlsFlags "github.com/snowflakedb/unshelled/auth/mtls/flags"
-	"github.com/snowflakedb/unshelled/server"
-
+	"github.com/Snowflake-Labs/sansshell/auth/mtls"
+	mtlsFlags "github.com/Snowflake-Labs/sansshell/auth/mtls/flags"
+	"github.com/Snowflake-Labs/sansshell/server"
 
 	// Import the server modules you want to expose, they automatically register
-	_ "github.com/snowflakedb/unshelled/services/exec"
-	_ "github.com/snowflakedb/unshelled/services/healthcheck"
-	_ "github.com/snowflakedb/unshelled/services/localfile"
+	_ "github.com/Snowflake-Labs/sansshell/services/exec"
+	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck"
+	_ "github.com/Snowflake-Labs/sansshell/services/localfile"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/snowflakedb/unshelled
+module github.com/Snowflake-Labs/sansshell
 
 go 1.17
 
@@ -11,18 +11,6 @@ require (
 )
 
 require (
-	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/yashtewari/glob-intersection v0.0.0-20180916065949-5c77d914dd0b // indirect
-	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
-	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/server/opa.go
+++ b/server/opa.go
@@ -37,7 +37,7 @@ type input struct {
 
 func NewOPA(policy string) (*OPA, error) {
 	r := rego.New(
-		rego.Query("x = data.unshelled.authz.allow"),
+		rego.Query("x = data.sansshell.authz.allow"),
 		rego.Module("builtin-policy.rego", policy),
 	)
 	pe, err := r.PrepareForEval(context.Background())

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/snowflakedb/unshelled/services"
+	"github.com/Snowflake-Labs/sansshell/services"
 )
 
 // Serve wraps up BuildServer in a succinct API for callers
@@ -26,7 +26,7 @@ func Serve(hostport string, c credentials.TransportCredentials, policy string) e
 }
 
 // BuildServer creates a gRPC server, attaches the OPA policy interceptor,
-// registers all of the imported Unshelled modules. Separating this from Serve
+// registers all of the imported SansShell modules. Separating this from Serve
 // primarily facilitates testing.
 func BuildServer(c credentials.TransportCredentials, policy string) (*grpc.Server, error) {
 	o, err := NewOPA(policy)
@@ -34,8 +34,8 @@ func BuildServer(c credentials.TransportCredentials, policy string) (*grpc.Serve
 		return &grpc.Server{}, fmt.Errorf("NewOpa: %w", err)
 	}
 	s := grpc.NewServer(grpc.Creds(c), grpc.UnaryInterceptor(o.Authorize), grpc.StreamInterceptor(o.AuthorizeStream))
-	for _, unshelledService := range services.ListServices() {
-		unshelledService.Register(s)
+	for _, sansShellService := range services.ListServices() {
+		sansShellService.Register(s)
 	}
 	return s, nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,13 +14,13 @@ import (
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
-	_ "github.com/snowflakedb/unshelled/services/healthcheck"
-	lf "github.com/snowflakedb/unshelled/services/localfile"
+	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck"
+	lf "github.com/Snowflake-Labs/sansshell/services/localfile"
 )
 
 const (
 	policy = `
-package unshelled.authz
+package sansshell.authz
 
 default allow = false
 
@@ -30,7 +30,7 @@ allow {
 }
 allow {
     input.type = "LocalFile.ReadRequest"
-		input.message.filename = "/no-such-filename-for-unshelled-unittest"
+		input.message.filename = "/no-such-filename-for-sansshell-unittest"
 }
 `
 )
@@ -79,11 +79,11 @@ func TestRead(t *testing.T) {
 			Err:      "",
 		},
 		{
-			Filename: "/no-such-filename-for-unshelled-unittest",
+			Filename: "/no-such-filename-for-sansshell-unittest",
 			Err:      "no such file or directory",
 		},
 		{
-			Filename: "/permission-denied-filename-for-unshelled-unittest",
+			Filename: "/permission-denied-filename-for-sansshell-unittest",
 			Err:      "PermissionDenied",
 		},
 	}

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
+	pb "github.com/Snowflake-Labs/sansshell/services/exec"
 	"github.com/google/subcommands"
-	pb "github.com/snowflakedb/unshelled/services/exec"
 	"google.golang.org/grpc"
 )
 

--- a/services/exec/exec.go
+++ b/services/exec/exec.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 
-	"github.com/snowflakedb/unshelled/services"
+	"github.com/Snowflake-Labs/sansshell/services"
 	grpc "google.golang.org/grpc"
 )
 
@@ -62,5 +62,5 @@ func (s *server) Register(gs *grpc.Server) {
 }
 
 func init() {
-	services.RegisterUnshelledService(&server{})
+	services.RegisterSansShellService(&server{})
 }

--- a/services/exec/exec.proto
+++ b/services/exec/exec.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/snowflakedb/unshelled/services/exec";
+option go_package = "github.com/Snowflake-Labs/sansshell/services/exec";
 
 package Exec;
 

--- a/services/healthcheck/client/client.go
+++ b/services/healthcheck/client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/subcommands"
 	"google.golang.org/grpc"
 
-	pb "github.com/snowflakedb/unshelled/services/healthcheck"
+	pb "github.com/Snowflake-Labs/sansshell/services/healthcheck"
 )
 
 func init() {

--- a/services/healthcheck/healthcheck.go
+++ b/services/healthcheck/healthcheck.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/snowflakedb/unshelled/services"
+	"github.com/Snowflake-Labs/sansshell/services"
 	grpc "google.golang.org/grpc"
 )
 
@@ -27,5 +27,5 @@ func (s *server) Register(gs *grpc.Server) {
 }
 
 func init() {
-	services.RegisterUnshelledService(&server{})
+	services.RegisterSansShellService(&server{})
 }

--- a/services/healthcheck/healthcheck.proto
+++ b/services/healthcheck/healthcheck.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/snowflakedb/unshelled/services/healthcheck";
+option go_package = "github.com/Snowflake-Labs/sansshell/services/healthcheck";
 
 package HealthCheck;
 

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/subcommands"
 	"google.golang.org/grpc"
 
-	pb "github.com/snowflakedb/unshelled/services/localfile"
+	pb "github.com/Snowflake-Labs/sansshell/services/localfile"
 )
 
 func init() {

--- a/services/localfile/localfile.go
+++ b/services/localfile/localfile.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/snowflakedb/unshelled/services"
+	"github.com/Snowflake-Labs/sansshell/services"
 	grpc "google.golang.org/grpc"
 )
 
@@ -93,5 +93,5 @@ func (s *server) Register(gs *grpc.Server) {
 }
 
 func init() {
-	services.RegisterUnshelledService(&server{})
+	services.RegisterSansShellService(&server{})
 }

--- a/services/localfile/localfile.proto
+++ b/services/localfile/localfile.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/snowflakedb/unshelled/services/localfile";
+option go_package = "github.com/Snowflake-Labs/sansshell/services/localfile";
 
 package LocalFile;
 

--- a/services/localfile/localfile_test.go
+++ b/services/localfile/localfile_test.go
@@ -87,7 +87,7 @@ func TestRead(t *testing.T) {
 		},
 		{
 			Name:     "bad-file",
-			Filename: "/no-such-filename-for-unshelled-unittest",
+			Filename: "/no-such-filename-for-sansshell-unittest",
 			Err:      "no such file or directory",
 		},
 	}

--- a/services/services.go
+++ b/services/services.go
@@ -8,23 +8,23 @@ import (
 
 var (
 	mu          sync.RWMutex
-	rpcServices []UnshelledRpcService
+	rpcServices []SansShellRpcService
 )
 
-type UnshelledRpcService interface {
+type SansShellRpcService interface {
 	Register(*grpc.Server)
 }
 
-// RegisterUnshelledService provides a mechanism for imported modules to
+// RegisterSansShellService provides a mechanism for imported modules to
 // register themselves with a gRPC server.
-func RegisterUnshelledService(s UnshelledRpcService) {
+func RegisterSansShellService(s SansShellRpcService) {
 	mu.Lock()
 	defer mu.Unlock()
 	rpcServices = append(rpcServices, s)
 }
 
 // ListServices returns the list of registered serfvices.
-func ListServices() []UnshelledRpcService {
+func ListServices() []SansShellRpcService {
 	mu.RLock()
 	defer mu.RUnlock()
 	return rpcServices


### PR DESCRIPTION
A former colleague at Google coined the very catchy name "Unshelled" for
a non-interactive local host agent.  I spoke with some former colleagues
about open sourcing that version, and everyone seemed amenable to the
idea.  I expected we would collaborate on it to make it suitable for use
outside Google, so I started talking about the idea internally at
Snowflake as Unshelled.  A few engineers left Google, the open sourcing
effort stalled, and it became clear it would not be released soon enough
for our needs.

I still expected that once both were released, we would work to converge
them, so I began writing an interim version at Snowflake and named it
Unshelled.  Before releasing it, I reached out to my former colleague
who coined the name, to ensure that they were okay with me using the
name, with this being the only public version if their version was never
released, and that if they did release theirs, at worst we'd converge
them.  Regrettably, they asked that I not use that name.  Out of
professional courtesy, I have agreed.

I’ve also sadly come to realize that they’re not really interested in
collaborating on a single open source project, and therefore these two
versions are unlikely to converge.  Having two open source projects with
the same name that bare little resemblance and are unlikely to converge
would be the worst outcome.

After considering many alternatives, I've settled on SansShell as the
new name.  It keeps close to the spirit of the original name, and has a
nice French twist in the theme of Snowflake project names.