### PR TITLE
Move ioutil.ReadFile to os.Readfile as it's just a pass through as of go1.16

### DIFF
--- a/auth/mtls/common.go
+++ b/auth/mtls/common.go
@@ -3,12 +3,12 @@ package mtls
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func LoadRootOfTrust(filename string) (*x509.CertPool, error) {
 	// Read in the root of trust for client identities
-	ca, err := ioutil.ReadFile(filename)
+	ca, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("could not read CA from %q: %w", filename, err)
 	}

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -9,8 +9,8 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
@@ -44,7 +44,7 @@ func choosePolicy() string {
 
 	var policy string
 	if *policyFile != "" {
-		pff, err := ioutil.ReadFile(*policyFile)
+		pff, err := os.ReadFile(*policyFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -126,7 +125,7 @@ func TestRead(t *testing.T) {
 				}
 			}
 
-			contents, err := ioutil.ReadFile(want.Filename)
+			contents, err := os.ReadFile(want.Filename)
 			if err != nil {
 				t.Fatalf("reading test data: %s", err)
 			}

--- a/services/localfile/server/localfile_test.go
+++ b/services/localfile/server/localfile_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -146,7 +145,7 @@ func TestRead(t *testing.T) {
 					t.Fatalf("Can't write into buffer: %v", err)
 				}
 			}
-			contents, err := ioutil.ReadFile(tc.Filename)
+			contents, err := os.ReadFile(tc.Filename)
 			if err != nil {
 				t.Fatalf("reading test data: %s", err)
 			}

--- a/services/packages/server/packages_test.go
+++ b/services/packages/server/packages_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -396,15 +395,9 @@ func TestListInstalled(t *testing.T) {
 		generateListInstalled = savedGenerateListInstalled
 	}()
 
-	f, err := os.Open(testdataGolden)
+	input, err := os.ReadFile(testdataGolden)
 	if err != nil {
-		t.Fatalf("Can't open testdata golden %s: %v", testdataGolden, err)
-	}
-	defer f.Close()
-
-	input, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatalf("Can't read textproto data from %s: %v", testdataGolden, err)
+		t.Fatalf("Can't read testdata golden  from %s: %v", testdataGolden, err)
 	}
 
 	testdata := &pb.ListInstalledReply{}
@@ -531,15 +524,9 @@ func TestRepoList(t *testing.T) {
 		generateRepoList = savedGenerateRepoList
 	}()
 
-	f, err := os.Open(testdataGolden)
+	input, err := os.ReadFile(testdataGolden)
 	if err != nil {
-		t.Fatalf("Can't open testdata golden %s: %v", testdataGolden, err)
-	}
-	defer f.Close()
-
-	input, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatalf("Can't read textproto data from %s: %v", testdataGolden, err)
+		t.Fatalf("Can't read testdata golde from %s: %v", testdataGolden, err)
 	}
 
 	testdata := &pb.RepoListReply{}


### PR DESCRIPTION
Also convert Open+ReadAll into os.Readfile since it does that.