### PR TITLE
logging: add client interceptors, add logging to proxy

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -10,12 +10,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-logr/stdr"
 	"google.golang.org/grpc"
 
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
 	mtlsFlags "github.com/Snowflake-Labs/sansshell/auth/mtls/flags"
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/proxy/server"
+	"github.com/Snowflake-Labs/sansshell/telemetry"
 
 	// Import services here to make them proxy-able
 	_ "github.com/Snowflake-Labs/sansshell/services/ansible"
@@ -36,22 +38,28 @@ func main() {
 
 	flag.Parse()
 
+	logOpts := log.Ldate | log.Ltime | log.Lshortfile
+	logger := stdr.New(log.New(os.Stderr, "", logOpts)).WithName("sanshell-proxy")
+
 	ctx := context.Background()
 
 	serverCreds, err := mtls.LoadServerCredentials(ctx, *credSource)
 	if err != nil {
-		log.Fatalf("mtls.LoadServerCredentials(%s) %v", *credSource, err)
+		logger.Error(err, "mtls.LoadServerCredentials", "credsource", *credSource)
+		os.Exit(1)
 	}
 	clientCreds, err := mtls.LoadClientCredentials(ctx, *credSource)
 	if err != nil {
-		log.Fatalf("mtls.LoadClientCredentials(%s) %v", *credSource, err)
+		logger.Error(err, "mtls.LoadClientCredentials", "credsource", *credSource)
+		os.Exit(1)
 	}
 
 	lis, err := net.Listen("tcp", *hostport)
 	if err != nil {
-		log.Fatalf("net.Listen(%s): %v", *hostport, err)
+		logger.Error(err, "net.Listen", "hostport", *hostport)
+		os.Exit(1)
 	}
-	log.Println("listening on", *hostport)
+	logger.Info("listening", "hostport", *hostport)
 
 	// TODO(jallie): implement the ability to 'hot reload' policy, since
 	// that could likely be done underneath the authorizer, with little
@@ -60,12 +68,13 @@ func main() {
 	if *policyFile != "" {
 		data, err := os.ReadFile(*policyFile)
 		if err != nil {
-			log.Fatalf("error reading policy file %s : %v", *policyFile, err)
+			logger.Error(err, "policy file read", "file", *policyFile)
+			os.Exit(1)
 		}
 		policy = string(data)
-		log.Println("using authorization policy from ", *policyFile)
+		logger.Info("using authorization policy from file", "file", *policyFile)
 	} else {
-		log.Println("using default authorization policy")
+		logger.Info("using default authorization policy")
 	}
 
 	addressHook := rpcauth.HookIf(rpcauth.HostNetHook(lis.Addr()), func(input *rpcauth.RpcAuthInput) bool {
@@ -73,18 +82,32 @@ func main() {
 	})
 	authz, err := rpcauth.NewWithPolicy(ctx, policy, addressHook)
 	if err != nil {
-		log.Fatalf("error initializing authorization : %v", err)
+		logger.Error(err, "rpcauth.NewWithPolicy")
+		os.Exit(1)
 	}
 
-	targetDialer := server.NewDialer(grpc.WithTransportCredentials(clientCreds))
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(clientCreds),
+		grpc.WithStreamInterceptor(telemetry.StreamClientLogInterceptor(logger)),
+	}
+	targetDialer := server.NewDialer(dialOpts...)
+
+	svcMap := server.LoadGlobalServiceMap()
+	logger.Info("loaded service map", "serviceMap", svcMap)
 	server := server.New(targetDialer, authz)
 
-	g := grpc.NewServer(grpc.Creds(serverCreds), grpc.StreamInterceptor(authz.AuthorizeStream))
+	serverOpts := []grpc.ServerOption{
+		grpc.Creds(serverCreds),
+		grpc.ChainStreamInterceptor(telemetry.StreamServerLogInterceptor(logger), authz.AuthorizeStream),
+	}
+	g := grpc.NewServer(serverOpts...)
 
 	server.Register(g)
-	log.Println("initialized Proxy service using credentials from", *credSource)
+	logger.Info("initialized proxy service", "credsource", *credSource)
+	logger.Info("serving..")
 
 	if err := g.Serve(lis); err != nil {
-		log.Fatalf("gRPCServer.Serve() %v", err)
+		logger.Error(err, "grpcserver.Serve()")
+		os.Exit(1)
 	}
 }

--- a/proxy/server/server.go
+++ b/proxy/server/server.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -72,7 +71,6 @@ func New(dialer TargetDialer, authorizer *rpcauth.Authorizer) *Server {
 // The supplied authorizer is used to authorize requests made
 // to targets.
 func NewWithServiceMap(dialer TargetDialer, authorizer *rpcauth.Authorizer, serviceMap map[string]*ServiceMethod) *Server {
-	log.Printf("service map: %+v", serviceMap)
 	return &Server{
 		serviceMap: serviceMap,
 		dialer:     dialer,
@@ -84,8 +82,6 @@ func NewWithServiceMap(dialer TargetDialer, authorizer *rpcauth.Authorizer, serv
 // stream which manages requests to a set of one or more backend
 // target servers
 func (s *Server) Proxy(stream pb.Proxy_ProxyServer) error {
-	log.Println("Received new proxy stream request")
-
 	requestChan := make(chan *pb.ProxyRequest)
 	replyChan := make(chan *pb.ProxyReply)
 


### PR DESCRIPTION
# Description

This PR expands the use of 'logr' logging to the proxy, and extends the telemetry package with client-side grpc log interceptors.

it also contains small changes to use the logr.Logger in for logging output in sanshell-server/main, and some various formattting improvments.

examples lines from proxy startup:

```
2021/11/19 21:47:05 main.go:62: sanshell-proxy: "level"=0 "msg"="listening" "hostport"="localhost:50043"
2021/11/19 21:47:05 main.go:77: sanshell-proxy: "level"=0 "msg"="using default authorization policy"
2021/11/19 21:47:05 main.go:96: sanshell-proxy: "level"=0 "msg"="loaded service map" "serviceMap"={"/Proxy.Proxy/Proxy":{},"/LocalFile.LocalFile/Sum":{},"/Packages.Packages/ListInstalled":{},"/Process.Process/List":{},"/Process.Process/GetJavaStacks":{},"/Process.Process/GetMemoryDump":{},"/Packages.Packages/Install":{},"/Exec.Exec/Run":{},"/Process.Process/GetStacks":{},"/Ansible.Playbook/Run":{},"/LocalFile.LocalFile/Read":{},"/LocalFile.LocalFile/Stat":{},"/LocalFile.LocalFile/Write":{},"/LocalFile.LocalFile/SetFileAttributes":{},"/HealthCheck.HealthCheck/Ok":{},"/LocalFile.LocalFile/Copy":{},"/Packages.Packages/Update":{},"/Packages.Packages/RepoList":{}}
2021/11/19 21:47:05 main.go:106: sanshell-proxy: "level"=0 "msg"="initialized proxy service" "credsource"="flags"
2021/11/19 21:47:05 main.go:107: sanshell-proxy: "level"=0 "msg"="serving.."
```