### PR TITLE
Proxy server: be tolerant of CloseSend() on completed target streams

### DIFF
--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -397,7 +397,12 @@ func (t *TargetStreamSet) ClientClose(req *pb.ClientClose) error {
 	for _, id := range req.StreamIds {
 		stream, ok := t.streams[id]
 		if !ok {
-			return status.Errorf(codes.InvalidArgument, "no such stream: %d", id)
+			// NB:
+			// Unlike other operations that accept a stream ID, ClientClosing
+			// a non-existent stream isn't a fatal error. This mirrors the native
+			// behavior of gRPC, which permits multiple calls to CloseSend, or
+			// a CloseSend on a stream which has already sent its last request.
+			continue
 		}
 		stream.CloseSend()
 	}

--- a/proxy/server/target_test.go
+++ b/proxy/server/target_test.go
@@ -57,11 +57,6 @@ func TestEmptyStreamSet(t *testing.T) {
 	ss.Wait()
 	close(finishedWait)
 
-	// Close of nonexistent ids is an error
-	if err := ss.ClientClose(&pb.ClientClose{StreamIds: []uint64{1}}); status.Code(err) != codes.InvalidArgument {
-		t.Errorf("TargetStream.ClientClose(1) err code was %v, want code.InvalidArgument", status.Code(err))
-	}
-
 	// Cancel of nonexistent ids is an error
 	if err := ss.ClientCancel(&pb.ClientCancel{StreamIds: []uint64{1}}); status.Code(err) != codes.InvalidArgument {
 		t.Errorf("TargetStream.ClientCancel(1) err code was %v, want code.InvalidArgument", status.Code(err))
@@ -74,6 +69,13 @@ func TestEmptyStreamSet(t *testing.T) {
 	if err := ss.Send(ctx, &pb.StreamData{StreamIds: []uint64{1}, Payload: payload}); status.Code(err) != codes.InvalidArgument {
 		t.Errorf("TargetStream.ClientCancel(0) err code was %v, want code.InvalidArgument", status.Code(err))
 	}
+
+	// Close of nonexistent ids is not an error, to match gRPC semantics which are tolerent of CloseSend on complete
+	// connections.
+	if err := ss.ClientClose(&pb.ClientClose{StreamIds: []uint64{1}}); status.Code(err) != codes.OK {
+		t.Errorf("TargetStream.ClientClose(1) err code was %v, want code.OK", status.Code(err))
+	}
+
 }
 
 func TestStreamSetAddErrors(t *testing.T) {


### PR DESCRIPTION
# Description
This PR changes the proxy server semantics to be tolerant of a CloseSend() received for a non-existent streamID. This essentially mirrors the behavior of native gRPC, which allows CloseSend() on (for example) a unary connection or a streaming connection that has already sent its final data.

The fixes a rare race condition in which a CloseSend() arrives after the proxy has already delivered a ServerClose() for a given stream (and removed it from the StreamSet). In this case, the resulting error would cause all other streams to be torn down (as it does for other cases in which a non-existent streamID is specified by the client). 

# Testing
Updated the target test to reflect that CloseSend() on a non-existent ID is a non-error, and also verified that the racing error (which manifested occasionally in proxy_test.go no longer occurs) (verified with zero failures over 10k runs). 