### PR TITLE
Run golint across whole tree.

### DIFF
--- a/auth/mtls/client.go
+++ b/auth/mtls/client.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// GetClientCredentials returns transport credentials for SansShell clients,
+// LoadClientCredentials returns transport credentials for SansShell clients,
 // based on the provided `loaderName`
 func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
 	loader, err := Loader(loaderName)

--- a/auth/mtls/common.go
+++ b/auth/mtls/common.go
@@ -22,6 +22,8 @@ import (
 	"os"
 )
 
+// LoadRootOfTrust will load an CA root of trust from the given
+// file and return a CertPool to use in validating certificates.
 func LoadRootOfTrust(filename string) (*x509.CertPool, error) {
 	// Read in the root of trust for client identities
 	ca, err := os.ReadFile(filename)

--- a/auth/mtls/flags/flags.go
+++ b/auth/mtls/flags/flags.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package flags provides flag support for loading client/server certs and CA root of trust.
 package flags
 
 import (
@@ -44,6 +45,7 @@ var (
 	rootCAFile                    string
 )
 
+// Name returns the loader to use to set mtls params via flags.
 func Name() string { return loaderName }
 
 // flagLoader implements mtls.CredentialsLoader by reading files specified

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -79,7 +79,7 @@ func Loader(name string) (CredentialsLoader, error) {
 	return loader, nil
 }
 
-// Loaders() returns the names of all currently registered CredentialLoader
+// Loaders returns the names of all currently registered CredentialLoader
 // implementations as a sorted list of strings.
 func Loaders() []string {
 	loaderMu.RLock()

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// GetServerCredentials returns transport credentials for a SansShell server as
+// LoadServerCredentials returns transport credentials for a SansShell server as
 // retrieved from the specified `loaderName`
 func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
 	loader, err := Loader(loaderName)

--- a/auth/opa/opa.go
+++ b/auth/opa/opa.go
@@ -14,7 +14,7 @@
    under the License.
 */
 
-// package opa contains code for performing authorization
+// Package opa contains code for performing authorization
 // checks using opa/rego.
 package opa
 
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	// The rego package used by all Sansshell policy files.
+	// SansshellRegoPackage is the rego package used by all Sansshell policy files.
 	// Any policy not using this package will be rejected.
 	SansshellRegoPackage = "sansshell.authz"
 
-	// The default query used for policy evaluation.
+	// DefaultAuthzQuery is the default query used for policy evaluation.
 	DefaultAuthzQuery = "data.sansshell.authz.allow"
 )
 
@@ -64,9 +64,9 @@ func (o optionFunc) apply(opts *policyOptions) {
 	o(opts)
 }
 
-// Use `query` to evaulate the policy, instead of DefaultAuthzQuery.
-// The supplied query should be simple evaluation expression that
-// creates no binding, and evaluates to 'true' iff the input
+// WithAllowQuery returns an option to use `query` to evaulate the policy,
+// instead of DefaultAuthzQuery. The supplied query should be simple evaluation
+// expressions that creates no binding, and evaluates to 'true' iff the input
 // satisfies the conditions of the policy.
 func WithAllowQuery(query string) Option {
 	return optionFunc(func(o *policyOptions) {

--- a/auth/opa/rpcauth/hooks.go
+++ b/auth/opa/rpcauth/hooks.go
@@ -21,19 +21,20 @@ import (
 	"net"
 )
 
-// AuthzHookFunc implements RpcAuthzHook for a simple function
-type RpcAuthzHookFunc func(context.Context, *RpcAuthInput) error
+// RPCAuthzHookFunc implements RpcAuthzHook for a simple function
+type RPCAuthzHookFunc func(context.Context, *RPCAuthInput) error
 
-func (r RpcAuthzHookFunc) Hook(ctx context.Context, input *RpcAuthInput) error {
+// Hook runs the hook function on the given input
+func (r RPCAuthzHookFunc) Hook(ctx context.Context, input *RPCAuthInput) error {
 	return r(ctx, input)
 }
 
-// An HookPredicate returns true if a conditional hook should run
-type HookPredicate func(*RpcAuthInput) bool
+// A HookPredicate returns true if a conditional hook should run
+type HookPredicate func(*RPCAuthInput) bool
 
 // HookIf wraps an existing hook, and only executes it when
 // the provided condition returns true
-func HookIf(hook RpcAuthzHook, condition HookPredicate) RpcAuthzHook {
+func HookIf(hook RPCAuthzHook, condition HookPredicate) RPCAuthzHook {
 	return &conditionalHook{
 		hook:      hook,
 		predicate: condition,
@@ -41,11 +42,11 @@ func HookIf(hook RpcAuthzHook, condition HookPredicate) RpcAuthzHook {
 }
 
 type conditionalHook struct {
-	hook      RpcAuthzHook
+	hook      RPCAuthzHook
 	predicate HookPredicate
 }
 
-func (c *conditionalHook) Hook(ctx context.Context, input *RpcAuthInput) error {
+func (c *conditionalHook) Hook(ctx context.Context, input *RPCAuthInput) error {
 	if c.predicate(input) {
 		return c.hook.Hook(ctx, input)
 	}
@@ -53,8 +54,8 @@ func (c *conditionalHook) Hook(ctx context.Context, input *RpcAuthInput) error {
 }
 
 // HostNetHook returns an RpcAuthzHook that sets host networking information.
-func HostNetHook(addr net.Addr) RpcAuthzHook {
-	return RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+func HostNetHook(addr net.Addr) RPCAuthzHook {
+	return RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 		if input.Host == nil {
 			input.Host = &HostAuthInput{}
 		}

--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -31,8 +31,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// RpcAuthInput is used as policy input to validate Sansshell RPCs
-type RpcAuthInput struct {
+// RPCAuthInput is used as policy input to validate Sansshell RPCs
+type RPCAuthInput struct {
 	// The GRPC method name, as '/Package.Service/Method'
 	Method string `json:"method"`
 
@@ -111,10 +111,10 @@ type PrincipalAuthInput struct {
 	Groups []string `json:"groups"`
 }
 
-// NewRpcAuthInput creates RpcAuthInput for the supplied method and request, deriving
+// NewRPCAuthInput creates RpcAuthInput for the supplied method and request, deriving
 // other information (if available) from the context.
-func NewRpcAuthInput(ctx context.Context, method string, req proto.Message) (*RpcAuthInput, error) {
-	out := &RpcAuthInput{
+func NewRPCAuthInput(ctx context.Context, method string, req proto.Message) (*RPCAuthInput, error) {
+	out := &RPCAuthInput{
 		Method: method,
 	}
 
@@ -147,7 +147,7 @@ func PeerInputFromContext(ctx context.Context) *PeerAuthInput {
 	return out
 }
 
-// NetInputFrom returns NetAuthInput from the supplied net.Addr
+// NetInputFromAddr returns NetAuthInput from the supplied net.Addr
 func NetInputFromAddr(addr net.Addr) *NetAuthInput {
 	if addr == nil {
 		return nil

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -88,27 +88,27 @@ func TestAuthzHook(t *testing.T) {
 
 	for _, tc := range []struct {
 		name    string
-		input   *RpcAuthInput
-		hooks   []RpcAuthzHook
+		input   *RPCAuthInput
+		hooks   []RPCAuthzHook
 		errFunc func(*testing.T, error)
 	}{
 		{
 			name:    "nil input, no hooks",
 			input:   nil,
-			hooks:   []RpcAuthzHook{},
+			hooks:   []RPCAuthzHook{},
 			errFunc: wantStatusCode(codes.InvalidArgument),
 		},
 		{
 			name:    "empty input, no hooks, deny",
-			input:   &RpcAuthInput{},
-			hooks:   []RpcAuthzHook{},
+			input:   &RPCAuthInput{},
+			hooks:   []RPCAuthzHook{},
 			errFunc: wantStatusCode(codes.PermissionDenied),
 		},
 		{
 			name:  "single hook, create allow",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					input.MessageType = "Foo.BazRequest"
 					return nil
@@ -118,13 +118,13 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "multiple hooks, create allow",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					return nil
 				}),
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.MessageType = "Foo.BazRequest"
 					return nil
 				}),
@@ -133,9 +133,9 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "single hook, hook reject with code",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					return status.Error(codes.FailedPrecondition, "hook failed")
 				}),
 			},
@@ -143,12 +143,12 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "multi-hook, first hook rejects with code",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					return status.Error(codes.FailedPrecondition, "hook failed")
 				}),
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					// never invoked
 					return nil
 				}),
@@ -157,12 +157,12 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "multi-hook, last hook rejects with code",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					return nil
 				}),
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					return status.Error(codes.FailedPrecondition, "hook failed")
 				}),
 			},
@@ -170,9 +170,9 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "single hook, hook reject without code",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					return errors.New("non status")
 				}),
 			},
@@ -180,14 +180,14 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "hook ordering",
-			input: &RpcAuthInput{},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					input.MessageType = "Foo.BarRequest"
 					return nil
 				}),
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.MessageType = "Foo.BazRequest"
 					return nil
 				}),
@@ -196,9 +196,9 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "synthesize data, allow",
-			input: &RpcAuthInput{Method: "/Foo.Bar/Foo"},
-			hooks: []RpcAuthzHook{
-				RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			input: &RPCAuthInput{Method: "/Foo.Bar/Foo"},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					if input.Peer == nil {
 						input.Peer = &PeerAuthInput{
 							Principal: &PrincipalAuthInput{
@@ -213,25 +213,25 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "synthesize network data, allow",
-			input: &RpcAuthInput{Method: "/Foo.Bar/Foo"},
-			hooks: []RpcAuthzHook{
+			input: &RPCAuthInput{Method: "/Foo.Bar/Foo"},
+			hooks: []RPCAuthzHook{
 				HostNetHook(tcp),
 			},
 			errFunc: wantStatusCode(codes.OK),
 		},
 		{
 			name:  "conditional hook, triggered",
-			input: &RpcAuthInput{Method: "/Some.Random/Method"},
+			input: &RPCAuthInput{Method: "/Some.Random/Method"},
 			// Set principal to admin if method = "/Some.Random/Method"
-			hooks: []RpcAuthzHook{
-				HookIf(RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			hooks: []RPCAuthzHook{
+				HookIf(RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Peer = &PeerAuthInput{
 						Principal: &PrincipalAuthInput{
 							ID: "admin@foo",
 						},
 					}
 					return nil
-				}), func(input *RpcAuthInput) bool {
+				}), func(input *RPCAuthInput) bool {
 					return input.Method == "/Some.Random/Method"
 				}),
 			},
@@ -239,17 +239,17 @@ func TestAuthzHook(t *testing.T) {
 		},
 		{
 			name:  "conditional hook, not-triggered",
-			input: &RpcAuthInput{Method: "/Some.Other/Method"},
+			input: &RPCAuthInput{Method: "/Some.Other/Method"},
 			// Set principal to admin if method = "/Some.Random/Method"
-			hooks: []RpcAuthzHook{
-				HookIf(RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+			hooks: []RPCAuthzHook{
+				HookIf(RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Peer = &PeerAuthInput{
 						Principal: &PrincipalAuthInput{
 							ID: "admin@foo",
 						},
 					}
 					return nil
-				}), func(input *RpcAuthInput) bool {
+				}), func(input *RPCAuthInput) bool {
 					return input.Method == "/Some.Random/Method"
 				}),
 			},
@@ -294,13 +294,13 @@ func TestRpcAuthInput(t *testing.T) {
 		ctx     context.Context
 		method  string
 		req     proto.Message
-		compare *RpcAuthInput
+		compare *RPCAuthInput
 	}{
 		{
 			name:   "method only",
 			ctx:    context.Background(),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method: "/AMethod",
 				Peer:   &PeerAuthInput{},
 			},
@@ -309,7 +309,7 @@ func TestRpcAuthInput(t *testing.T) {
 			name:   "method and metadata",
 			ctx:    metadata.NewIncomingContext(context.Background(), md),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method:   "/AMethod",
 				Metadata: md,
 				Peer:     &PeerAuthInput{},
@@ -320,7 +320,7 @@ func TestRpcAuthInput(t *testing.T) {
 			ctx:    context.Background(),
 			method: "/AMethod",
 			req:    &emptypb.Empty{},
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method:      "/AMethod",
 				Message:     json.RawMessage{0x7b, 0x7d},
 				MessageType: "google.protobuf.Empty",
@@ -331,7 +331,7 @@ func TestRpcAuthInput(t *testing.T) {
 			name:   "method and a peer context but no addr",
 			ctx:    peer.NewContext(context.Background(), &peer.Peer{}),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method: "/AMethod",
 				Peer:   &PeerAuthInput{},
 			},
@@ -342,7 +342,7 @@ func TestRpcAuthInput(t *testing.T) {
 				Addr: tcp,
 			}),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method: "/AMethod",
 				Peer: &PeerAuthInput{
 					Net: &NetAuthInput{
@@ -360,7 +360,7 @@ func TestRpcAuthInput(t *testing.T) {
 				AuthInfo: testAuthInfo{},
 			}),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method: "/AMethod",
 				Peer: &PeerAuthInput{
 					Net: &NetAuthInput{
@@ -388,7 +388,7 @@ func TestRpcAuthInput(t *testing.T) {
 				},
 			}),
 			method: "/AMethod",
-			compare: &RpcAuthInput{
+			compare: &RPCAuthInput{
 				Method: "/AMethod",
 				Peer: &PeerAuthInput{
 					Net: &NetAuthInput{
@@ -403,7 +403,7 @@ func TestRpcAuthInput(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			rpcauth, err := NewRpcAuthInput(tc.ctx, tc.method, tc.req)
+			rpcauth, err := NewRPCAuthInput(tc.ctx, tc.method, tc.req)
 			testutil.FatalOnErr(tc.name, err, t)
 			testutil.DiffErr(tc.name, rpcauth, tc.compare, t)
 		})
@@ -437,7 +437,7 @@ func TestAuthorize(t *testing.T) {
 	}
 
 	// Create one with a hook so we can fail.
-	authorizer, err = NewWithPolicy(context.Background(), policyString, RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+	authorizer, err = NewWithPolicy(context.Background(), policyString, RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 		return status.Error(codes.FailedPrecondition, "hook failed")
 	}))
 	testutil.FatalOnErr("NewWithPolicy with hooks", err, t)
@@ -487,7 +487,7 @@ func TestAuthorizeStream(t *testing.T) {
 	testutil.FatalOnNoErr("AuthorizeStream non proto", err, t)
 
 	// Create one with a hook so we can fail.
-	authorizer, err = NewWithPolicy(context.Background(), policyString, RpcAuthzHookFunc(func(ctx context.Context, input *RpcAuthInput) error {
+	authorizer, err = NewWithPolicy(context.Background(), policyString, RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 		return status.Error(codes.FailedPrecondition, "hook failed")
 	}))
 	testutil.FatalOnErr("NewWithPolicy with hooks", err, t)

--- a/client/client.go
+++ b/client/client.go
@@ -14,6 +14,8 @@
    under the License.
 */
 
+// Package client provides utility functions for gluing new commands
+// easily into sanssh.
 package client
 
 import (
@@ -24,6 +26,9 @@ import (
 	"github.com/google/subcommands"
 )
 
+// SetupSubpackage is a helper to create a Commander to hold the actual
+// commands run inside of a top-level command. The returned Commander should
+// then have the relevant sub-commands registered within it.
 func SetupSubpackage(name string, f *flag.FlagSet) *subcommands.Commander {
 	c := subcommands.NewCommander(f, name)
 	c.Register(c.HelpCommand(), "")
@@ -32,6 +37,8 @@ func SetupSubpackage(name string, f *flag.FlagSet) *subcommands.Commander {
 	return c
 }
 
+// GenerateSynopsis will generate a consistent snnopysis for a top level command
+// with N sub-commands contained within it.
 func GenerateSynopsis(c *subcommands.Commander) string {
 	b := &bytes.Buffer{}
 	b.WriteString("\n")
@@ -47,6 +54,8 @@ func GenerateSynopsis(c *subcommands.Commander) string {
 	return b.String()
 }
 
+// GenerateUsage will return a usage string to a top level command with N
+// sub-commands contained within it.
 func GenerateUsage(name string, synopsis string) string {
 	return fmt.Sprintf("%s has several subcommands. Pick one to perform the action you wish:\n%s", name, synopsis)
 }

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -94,7 +94,7 @@ func main() {
 		logger.Info("using default authorization policy")
 	}
 
-	addressHook := rpcauth.HookIf(rpcauth.HostNetHook(lis.Addr()), func(input *rpcauth.RpcAuthInput) bool {
+	addressHook := rpcauth.HookIf(rpcauth.HostNetHook(lis.Addr()), func(input *rpcauth.RPCAuthInput) bool {
 		return input.Host == nil || input.Host.Net == nil
 	})
 	authz, err := rpcauth.NewWithPolicy(ctx, policy, addressHook)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package proxy defines the RPC interface for the sansshell proxy server.
 package proxy
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/proxy/proxy/proxy_test.go
+++ b/proxy/proxy/proxy_test.go
@@ -45,7 +45,7 @@ func startTestProxy(ctx context.Context, t *testing.T, targets map[string]*bufco
 	t.Helper()
 	targetDialer := server.NewDialer(testutil.WithBufDialer(targets), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	lis := bufconn.Listen(testutil.BufSize)
-	authz := testutil.NewAllowAllRpcAuthorizer(ctx, t)
+	authz := testutil.NewAllowAllRPCAuthorizer(ctx, t)
 	grpcServer := grpc.NewServer(grpc.StreamInterceptor(authz.AuthorizeStream))
 	proxyServer := server.New(targetDialer, authz)
 	proxyServer.Register(grpcServer)
@@ -327,7 +327,7 @@ func TestWithFakeServerForErrors(t *testing.T) {
 	// Setup our fake server.
 	ctx := context.Background()
 	lis := bufconn.Listen(testutil.BufSize)
-	authz := testutil.NewAllowAllRpcAuthorizer(ctx, t)
+	authz := testutil.NewAllowAllRPCAuthorizer(ctx, t)
 	grpcServer := grpc.NewServer(grpc.StreamInterceptor(authz.AuthorizeStream))
 	fp := &fakeProxy{}
 	proxypb.RegisterProxyServer(grpcServer, fp)

--- a/proxy/server/server.go
+++ b/proxy/server/server.go
@@ -14,8 +14,8 @@
    under the License.
 */
 
-// package server provides the server-side implementation of the
-// sansshell proxy server
+// Package server provides the server-side implementation of the
+// sansshell proxy server.
 package server
 
 import (

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -409,7 +409,7 @@ func (t *TargetStreamSet) ClientClose(req *pb.ClientClose) error {
 	return nil
 }
 
-// ClientCloseAll() issues ClientClose to all associated TargetStreams
+// ClientCloseAll issues ClientClose to all associated TargetStreams
 func (t *TargetStreamSet) ClientCloseAll() {
 	for _, stream := range t.streams {
 		stream.CloseSend()
@@ -459,7 +459,7 @@ func (t *TargetStreamSet) Send(ctx context.Context, req *pb.StreamData) error {
 			return status.Errorf(codes.InvalidArgument, "invalid request type for method %s", stream.Method())
 		}
 
-		authinput, err := rpcauth.NewRpcAuthInput(ctx, stream.Method(), streamReq)
+		authinput, err := rpcauth.NewRPCAuthInput(ctx, stream.Method(), streamReq)
 		if err != nil {
 			return status.Errorf(codes.Internal, "error creating authz input %v", err)
 		}

--- a/proxy/testdata/testservice_grpcproxy.pb.go
+++ b/proxy/testdata/testservice_grpcproxy.pb.go
@@ -31,14 +31,16 @@ type testServiceClientProxy struct {
 }
 
 // NewTestServiceClientProxy creates a TestServiceClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewTestServiceClientProxy(cc *proxy.ProxyConn) TestServiceClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewTestServiceClientProxy(cc *proxy.Conn) TestServiceClientProxy {
 	return &testServiceClientProxy{NewTestServiceClient(cc).(*testServiceClient)}
 }
 
+// TestUnaryManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type TestUnaryManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *TestResponse
 	Error error
@@ -49,7 +51,7 @@ type TestUnaryManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *testServiceClientProxy) TestUnaryOneMany(ctx context.Context, in *TestRequest, opts ...grpc.CallOption) (<-chan *TestUnaryManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *TestUnaryManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -101,9 +103,11 @@ func (c *testServiceClientProxy) TestUnaryOneMany(ctx context.Context, in *TestR
 	return ret, nil
 }
 
+// TestServerStreamManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type TestServerStreamManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *TestResponse
 	Error error
@@ -115,7 +119,7 @@ type TestService_TestServerStreamClientProxy interface {
 }
 
 type testServiceClientTestServerStreamClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -147,7 +151,7 @@ func (x *testServiceClientTestServerStreamClientProxy) Recv() ([]*TestServerStre
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -177,7 +181,7 @@ func (c *testServiceClientProxy) TestServerStreamOneMany(ctx context.Context, in
 	if err != nil {
 		return nil, err
 	}
-	x := &testServiceClientTestServerStreamClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &testServiceClientTestServerStreamClientProxy{c.cc.(*proxy.Conn), false, stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -187,9 +191,11 @@ func (c *testServiceClientProxy) TestServerStreamOneMany(ctx context.Context, in
 	return x, nil
 }
 
+// TestClientStreamManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type TestClientStreamManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *TestResponse
 	Error error
@@ -202,7 +208,7 @@ type TestService_TestClientStreamClientProxy interface {
 }
 
 type testServiceClientTestClientStreamClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -257,7 +263,7 @@ func (x *testServiceClientTestClientStreamClientProxy) CloseAndRecv() ([]*TestCl
 		if done {
 			break
 		}
-		m := []*proxy.ProxyRet{}
+		m := []*proxy.Ret{}
 		if err := x.ClientStream.RecvMsg(&m); err != nil {
 			return nil, err
 		}
@@ -288,13 +294,15 @@ func (c *testServiceClientProxy) TestClientStreamOneMany(ctx context.Context, op
 	if err != nil {
 		return nil, err
 	}
-	x := &testServiceClientTestClientStreamClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &testServiceClientTestClientStreamClientProxy{c.cc.(*proxy.Conn), false, stream}
 	return x, nil
 }
 
+// TestBidiStreamManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type TestBidiStreamManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *TestResponse
 	Error error
@@ -307,7 +315,7 @@ type TestService_TestBidiStreamClientProxy interface {
 }
 
 type testServiceClientTestBidiStreamClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -343,7 +351,7 @@ func (x *testServiceClientTestBidiStreamClientProxy) Recv() ([]*TestBidiStreamMa
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -373,6 +381,6 @@ func (c *testServiceClientProxy) TestBidiStreamOneMany(ctx context.Context, opts
 	if err != nil {
 		return nil, err
 	}
-	x := &testServiceClientTestBidiStreamClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &testServiceClientTestBidiStreamClientProxy{c.cc.(*proxy.Conn), false, stream}
 	return x, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server provides helpers for building and running a sansshell server.
 package server
 
 import (

--- a/services/ansible/ansible.go
+++ b/services/ansible/ansible.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package ansible defines the RPC interface for the sansshell Ansible actions.
 package ansible
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/ansible/ansible_grpcproxy.pb.go
+++ b/services/ansible/ansible_grpcproxy.pb.go
@@ -27,14 +27,16 @@ type playbookClientProxy struct {
 }
 
 // NewPlaybookClientProxy creates a PlaybookClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewPlaybookClientProxy(cc *proxy.ProxyConn) PlaybookClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewPlaybookClientProxy(cc *proxy.Conn) PlaybookClientProxy {
 	return &playbookClientProxy{NewPlaybookClient(cc).(*playbookClient)}
 }
 
+// RunManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type RunManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *RunReply
 	Error error
@@ -45,7 +47,7 @@ type RunManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *playbookClientProxy) RunOneMany(ctx context.Context, in *RunRequest, opts ...grpc.CallOption) (<-chan *RunManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *RunManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/ansible/client/client.go
+++ b/services/ansible/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'ansible'
 package client
 
 import (

--- a/services/ansible/server/ansible.go
+++ b/services/ansible/server/ansible.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'Ansible' service.
 package server
 
 import (

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'exec'
 package client
 
 import (

--- a/services/exec/exec.go
+++ b/services/exec/exec.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package exec defines the RPC interface for the sansshell Exec actions.
 package exec
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/exec/exec_grpcproxy.pb.go
+++ b/services/exec/exec_grpcproxy.pb.go
@@ -27,14 +27,16 @@ type execClientProxy struct {
 }
 
 // NewExecClientProxy creates a ExecClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewExecClientProxy(cc *proxy.ProxyConn) ExecClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewExecClientProxy(cc *proxy.Conn) ExecClientProxy {
 	return &execClientProxy{NewExecClient(cc).(*execClient)}
 }
 
+// RunManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type RunManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ExecResponse
 	Error error
@@ -45,7 +47,7 @@ type RunManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *execClientProxy) RunOneMany(ctx context.Context, in *ExecRequest, opts ...grpc.CallOption) (<-chan *RunManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *RunManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/exec/server/exec.go
+++ b/services/exec/server/exec.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'Exec' service.
 package server
 
 import (

--- a/services/healthcheck/client/client.go
+++ b/services/healthcheck/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'healthcheck'
 package client
 
 import (

--- a/services/healthcheck/healthcheck.go
+++ b/services/healthcheck/healthcheck.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package healthcheck defines the RPC interface for the sansshell HealthCheck actions.
 package healthcheck
 
 // To regenerate the proto headers if the proto changes, just run go generate

--- a/services/healthcheck/healthcheck_grpcproxy.pb.go
+++ b/services/healthcheck/healthcheck_grpcproxy.pb.go
@@ -28,14 +28,16 @@ type healthCheckClientProxy struct {
 }
 
 // NewHealthCheckClientProxy creates a HealthCheckClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewHealthCheckClientProxy(cc *proxy.ProxyConn) HealthCheckClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewHealthCheckClientProxy(cc *proxy.Conn) HealthCheckClientProxy {
 	return &healthCheckClientProxy{NewHealthCheckClient(cc).(*healthCheckClient)}
 }
 
+// OkManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type OkManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -46,7 +48,7 @@ type OkManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *healthCheckClientProxy) OkOneMany(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (<-chan *OkManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *OkManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/healthcheck/server/healthcheck.go
+++ b/services/healthcheck/server/healthcheck.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'HealthCheck' service.
 package server
 
 import (

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'file'
 package client
 
 import (
@@ -110,7 +111,7 @@ func (p *readCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 		},
 	}
 
-	err := ReadFile(ctx, state, req)
+	err := readFile(ctx, state, req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not read file %s: %v\n", filename, err)
 		return subcommands.ExitFailure
@@ -118,7 +119,7 @@ func (p *readCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 	return subcommands.ExitSuccess
 }
 
-func ReadFile(ctx context.Context, state *util.ExecuteState, req *pb.ReadActionRequest) error {
+func readFile(ctx context.Context, state *util.ExecuteState, req *pb.ReadActionRequest) error {
 	c := pb.NewLocalFileClientProxy(state.Conn)
 	stream, err := c.ReadOneMany(ctx, req)
 	if err != nil {
@@ -187,7 +188,7 @@ func (p *tailCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 		},
 	}
 
-	err := ReadFile(ctx, state, req)
+	err := readFile(ctx, state, req)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not tail file: %v\n", err)
 		return subcommands.ExitFailure

--- a/services/localfile/localfile.go
+++ b/services/localfile/localfile.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package localfile defines the RPC interface for the sansshell LocalFile actions.
 package localfile
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/localfile/localfile_grpcproxy.pb.go
+++ b/services/localfile/localfile_grpcproxy.pb.go
@@ -37,14 +37,16 @@ type localFileClientProxy struct {
 }
 
 // NewLocalFileClientProxy creates a LocalFileClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewLocalFileClientProxy(cc *proxy.ProxyConn) LocalFileClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewLocalFileClientProxy(cc *proxy.Conn) LocalFileClientProxy {
 	return &localFileClientProxy{NewLocalFileClient(cc).(*localFileClient)}
 }
 
+// ReadManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ReadManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ReadReply
 	Error error
@@ -56,7 +58,7 @@ type LocalFile_ReadClientProxy interface {
 }
 
 type localFileClientReadClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -88,7 +90,7 @@ func (x *localFileClientReadClientProxy) Recv() ([]*ReadManyResponse, error) {
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -118,7 +120,7 @@ func (c *localFileClientProxy) ReadOneMany(ctx context.Context, in *ReadActionRe
 	if err != nil {
 		return nil, err
 	}
-	x := &localFileClientReadClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &localFileClientReadClientProxy{c.cc.(*proxy.Conn), false, stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -128,9 +130,11 @@ func (c *localFileClientProxy) ReadOneMany(ctx context.Context, in *ReadActionRe
 	return x, nil
 }
 
+// StatManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type StatManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *StatReply
 	Error error
@@ -143,7 +147,7 @@ type LocalFile_StatClientProxy interface {
 }
 
 type localFileClientStatClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -179,7 +183,7 @@ func (x *localFileClientStatClientProxy) Recv() ([]*StatManyResponse, error) {
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -209,13 +213,15 @@ func (c *localFileClientProxy) StatOneMany(ctx context.Context, opts ...grpc.Cal
 	if err != nil {
 		return nil, err
 	}
-	x := &localFileClientStatClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &localFileClientStatClientProxy{c.cc.(*proxy.Conn), false, stream}
 	return x, nil
 }
 
+// SumManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type SumManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *SumReply
 	Error error
@@ -228,7 +234,7 @@ type LocalFile_SumClientProxy interface {
 }
 
 type localFileClientSumClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -264,7 +270,7 @@ func (x *localFileClientSumClientProxy) Recv() ([]*SumManyResponse, error) {
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -294,13 +300,15 @@ func (c *localFileClientProxy) SumOneMany(ctx context.Context, opts ...grpc.Call
 	if err != nil {
 		return nil, err
 	}
-	x := &localFileClientSumClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &localFileClientSumClientProxy{c.cc.(*proxy.Conn), false, stream}
 	return x, nil
 }
 
+// WriteManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type WriteManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -313,7 +321,7 @@ type LocalFile_WriteClientProxy interface {
 }
 
 type localFileClientWriteClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -368,7 +376,7 @@ func (x *localFileClientWriteClientProxy) CloseAndRecv() ([]*WriteManyResponse, 
 		if done {
 			break
 		}
-		m := []*proxy.ProxyRet{}
+		m := []*proxy.Ret{}
 		if err := x.ClientStream.RecvMsg(&m); err != nil {
 			return nil, err
 		}
@@ -399,13 +407,15 @@ func (c *localFileClientProxy) WriteOneMany(ctx context.Context, opts ...grpc.Ca
 	if err != nil {
 		return nil, err
 	}
-	x := &localFileClientWriteClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &localFileClientWriteClientProxy{c.cc.(*proxy.Conn), false, stream}
 	return x, nil
 }
 
+// CopyManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type CopyManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -416,7 +426,7 @@ type CopyManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *localFileClientProxy) CopyOneMany(ctx context.Context, in *CopyRequest, opts ...grpc.CallOption) (<-chan *CopyManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *CopyManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -468,9 +478,11 @@ func (c *localFileClientProxy) CopyOneMany(ctx context.Context, in *CopyRequest,
 	return ret, nil
 }
 
+// ListManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ListManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ListReply
 	Error error
@@ -482,7 +494,7 @@ type LocalFile_ListClientProxy interface {
 }
 
 type localFileClientListClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -514,7 +526,7 @@ func (x *localFileClientListClientProxy) Recv() ([]*ListManyResponse, error) {
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -544,7 +556,7 @@ func (c *localFileClientProxy) ListOneMany(ctx context.Context, in *ListRequest,
 	if err != nil {
 		return nil, err
 	}
-	x := &localFileClientListClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &localFileClientListClientProxy{c.cc.(*proxy.Conn), false, stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -554,9 +566,11 @@ func (c *localFileClientProxy) ListOneMany(ctx context.Context, in *ListRequest,
 	return x, nil
 }
 
+// SetFileAttributesManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type SetFileAttributesManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -567,7 +581,7 @@ type SetFileAttributesManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *localFileClientProxy) SetFileAttributesOneMany(ctx context.Context, in *SetFileAttributesRequest, opts ...grpc.CallOption) (<-chan *SetFileAttributesManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *SetFileAttributesManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -619,9 +633,11 @@ func (c *localFileClientProxy) SetFileAttributesOneMany(ctx context.Context, in 
 	return ret, nil
 }
 
+// RmManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type RmManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -632,7 +648,7 @@ type RmManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *localFileClientProxy) RmOneMany(ctx context.Context, in *RmRequest, opts ...grpc.CallOption) (<-chan *RmManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *RmManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -684,9 +700,11 @@ func (c *localFileClientProxy) RmOneMany(ctx context.Context, in *RmRequest, opt
 	return ret, nil
 }
 
+// RmdirManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type RmdirManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *emptypb.Empty
 	Error error
@@ -697,7 +715,7 @@ type RmdirManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *localFileClientProxy) RmdirOneMany(ctx context.Context, in *RmdirRequest, opts ...grpc.CallOption) (<-chan *RmdirManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *RmdirManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/localfile/server/localfile.go
+++ b/services/localfile/server/localfile.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'LocalFile' service.
 package server
 
 import (
@@ -33,9 +34,9 @@ import (
 	"time"
 
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/azureblob"
-	_ "gocloud.dev/blob/gcsblob"
-	_ "gocloud.dev/blob/s3blob"
+	_ "gocloud.dev/blob/azureblob" // Pull in Azure blob support
+	_ "gocloud.dev/blob/gcsblob"   // Pull in GCS blob support
+	_ "gocloud.dev/blob/s3blob"    // Pull in S3 blob support
 
 	"github.com/Snowflake-Labs/sansshell/services"
 	pb "github.com/Snowflake-Labs/sansshell/services/localfile"
@@ -51,15 +52,16 @@ import (
 )
 
 var (
+	// AbsolutePathError is a typed error for path errors on file/directory names.
 	AbsolutePathError = status.Error(codes.InvalidArgument, "filename path must be absolute and clean")
 
 	// For testing since otherwise tests have to run as root for these.
 	chown             = unix.Chown
 	changeImmutableOS = changeImmutable
 
-	// READ_TIMEOUT is how long tail should wait on a given poll call
+	// ReadTimeout is how long tail should wait on a given poll call
 	// before checking context.Err() and possibly looping.
-	READ_TIMEOUT = 10 * time.Second
+	ReadTimeout = 10 * time.Second
 )
 
 // This encompasses the permission plus the setuid/gid/sticky bits one

--- a/services/localfile/server/localfile_darwin.go
+++ b/services/localfile/server/localfile_darwin.go
@@ -148,7 +148,7 @@ func dataReady(kq interface{}, stream pb.LocalFile_ReadServer) error {
 
 		// Wait 10s in between requests so we can check the stream context too.
 		ts := &unix.Timespec{
-			Sec: int64(READ_TIMEOUT.Seconds()),
+			Sec: int64(ReadTimeout.Seconds()),
 		}
 		n, err := kevent(kqf.kqFD, nil, events, ts)
 		if err != nil {

--- a/services/localfile/server/localfile_test.go
+++ b/services/localfile/server/localfile_test.go
@@ -204,7 +204,7 @@ func TestTail(t *testing.T) {
 	testutil.FatalOnErr("grpc.DialContext(bufnet)", err, t)
 	t.Cleanup(func() { conn.Close() })
 
-	READ_TIMEOUT = 1 * time.Second
+	ReadTimeout = 1 * time.Second
 
 	// Create a file with some initial data.
 	temp := t.TempDir()
@@ -255,7 +255,7 @@ func TestTail(t *testing.T) {
 
 	// Pause n+1s to make sure the server goes through a poll loop if we're
 	// not on an OS that can immediately return.
-	time.Sleep(READ_TIMEOUT + 1*time.Second)
+	time.Sleep(ReadTimeout + 1*time.Second)
 
 	// This should cause Recv() to fail
 	resp, err = stream.Recv()
@@ -526,7 +526,7 @@ func TestSetFileAttributes(t *testing.T) {
 	testutil.FatalOnErr("chmod", err, t)
 
 	setPath := ""
-	setUid, setGid := 0, 0
+	setUID, setGID := 0, 0
 	setImmutable, chownError, immutableError := false, false, false
 
 	// Setup a mock chown so we can tell it's getting called
@@ -534,8 +534,8 @@ func TestSetFileAttributes(t *testing.T) {
 	savedChown := chown
 	chown = func(path string, uid int, gid int) error {
 		setPath = path
-		setUid = uid
-		setGid = gid
+		setUID = uid
+		setGID = gid
 		if chownError {
 			return errors.New("chown error")
 		}
@@ -568,10 +568,10 @@ func TestSetFileAttributes(t *testing.T) {
 		wantErr           bool
 		chownError        bool
 		immutableError    bool
-		setUid            bool
-		expectedUid       int
-		setGid            bool
-		expectedGid       int
+		setUID            bool
+		expectedUID       int
+		setGID            bool
+		expectedGID       int
 		setMode           bool
 		expectedMode      uint32
 		setImmutable      bool
@@ -751,10 +751,10 @@ func TestSetFileAttributes(t *testing.T) {
 					},
 				},
 			},
-			setUid:            true,
-			expectedUid:       uid + 1,
-			setGid:            true,
-			expectedGid:       gid + 1,
+			setUID:            true,
+			expectedUID:       uid + 1,
+			setGID:            true,
+			expectedGID:       gid + 1,
 			setMode:           true,
 			expectedMode:      f1Stat.Mode + 1,
 			setImmutable:      true,
@@ -830,13 +830,13 @@ func TestSetFileAttributes(t *testing.T) {
 			if got, want := setPath, tc.input.Attrs.Filename; got != want {
 				t.Fatalf("%s: didn't use correct path. Got %s and want %s", tc.name, got, want)
 			}
-			if tc.setUid {
-				if got, want := setUid, tc.expectedUid; got != want {
+			if tc.setUID {
+				if got, want := setUID, tc.expectedUID; got != want {
 					t.Fatalf("%s: didn't use correct uid. Got %d and want %d", tc.name, got, want)
 				}
 			}
-			if tc.setGid {
-				if got, want := setGid, tc.expectedGid; got != want {
+			if tc.setGID {
+				if got, want := setGID, tc.expectedGID; got != want {
 					t.Fatalf("%s: didn't use correct gid. Got %d and want %d", tc.name, got, want)
 				}
 			}

--- a/services/packages/client/client.go
+++ b/services/packages/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'packages'
 package client
 
 import (
@@ -140,8 +141,8 @@ func (i *installCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 type updateCmd struct {
 	packageSystem string
 	name          string
-	old_version   string
-	new_version   string
+	oldVersion    string
+	newVersion    string
 	repo          string
 }
 
@@ -156,13 +157,13 @@ func (*updateCmd) Usage() string {
 func (u *updateCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&u.packageSystem, "package-system", "YUM", fmt.Sprintf("Package system to use(one of: [%s])", strings.Join(shortPackageSystemNames(), ",")))
 	f.StringVar(&u.name, "name", "", "Name of package to install")
-	f.StringVar(&u.old_version, "old_version", "", "Old version of package which must be on the system. For YUM this must be a full nevra version")
-	f.StringVar(&u.new_version, "new_version", "", "New version of package to update. For YUM this must be a full nevra version")
+	f.StringVar(&u.oldVersion, "old_version", "", "Old version of package which must be on the system. For YUM this must be a full nevra version")
+	f.StringVar(&u.newVersion, "new_version", "", "New version of package to update. For YUM this must be a full nevra version")
 	f.StringVar(&u.repo, "repo", "", "If set also enable this repo when resolving packages.")
 }
 
 func (u *updateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	if u.name == "" || u.old_version == "" || u.new_version == "" {
+	if u.name == "" || u.oldVersion == "" || u.newVersion == "" {
 		fmt.Fprintln(os.Stderr, "--name, --old_version and --new_version must be supplied")
 		return subcommands.ExitFailure
 	}
@@ -179,8 +180,8 @@ func (u *updateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 	req := &pb.UpdateRequest{
 		PackageSystem: ps,
 		Name:          u.name,
-		OldVersion:    u.old_version,
-		NewVersion:    u.new_version,
+		OldVersion:    u.oldVersion,
+		NewVersion:    u.newVersion,
 		Repo:          u.repo,
 	}
 

--- a/services/packages/packages.go
+++ b/services/packages/packages.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package packages defines the RPC interface for the sansshell Packages actions.
 package packages
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/packages/packages_grpcproxy.pb.go
+++ b/services/packages/packages_grpcproxy.pb.go
@@ -30,14 +30,16 @@ type packagesClientProxy struct {
 }
 
 // NewPackagesClientProxy creates a PackagesClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewPackagesClientProxy(cc *proxy.ProxyConn) PackagesClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewPackagesClientProxy(cc *proxy.Conn) PackagesClientProxy {
 	return &packagesClientProxy{NewPackagesClient(cc).(*packagesClient)}
 }
 
+// InstallManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type InstallManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *InstallReply
 	Error error
@@ -48,7 +50,7 @@ type InstallManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *packagesClientProxy) InstallOneMany(ctx context.Context, in *InstallRequest, opts ...grpc.CallOption) (<-chan *InstallManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *InstallManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -100,9 +102,11 @@ func (c *packagesClientProxy) InstallOneMany(ctx context.Context, in *InstallReq
 	return ret, nil
 }
 
+// UpdateManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type UpdateManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *UpdateReply
 	Error error
@@ -113,7 +117,7 @@ type UpdateManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *packagesClientProxy) UpdateOneMany(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (<-chan *UpdateManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *UpdateManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -165,9 +169,11 @@ func (c *packagesClientProxy) UpdateOneMany(ctx context.Context, in *UpdateReque
 	return ret, nil
 }
 
+// ListInstalledManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ListInstalledManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ListInstalledReply
 	Error error
@@ -178,7 +184,7 @@ type ListInstalledManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *packagesClientProxy) ListInstalledOneMany(ctx context.Context, in *ListInstalledRequest, opts ...grpc.CallOption) (<-chan *ListInstalledManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *ListInstalledManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -230,9 +236,11 @@ func (c *packagesClientProxy) ListInstalledOneMany(ctx context.Context, in *List
 	return ret, nil
 }
 
+// RepoListManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type RepoListManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *RepoListReply
 	Error error
@@ -243,7 +251,7 @@ type RepoListManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *packagesClientProxy) RepoListOneMany(ctx context.Context, in *RepoListRequest, opts ...grpc.CallOption) (<-chan *RepoListManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *RepoListManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/packages/server/packages.go
+++ b/services/packages/server/packages.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'Packages' service.
 package server
 
 import (
@@ -349,10 +350,10 @@ func parseYumRepoListOutput(r io.Reader) (*pb.RepoListReply, error) {
 		text := scanner.Text()
 		fields := strings.Fields(text)
 
-		const MIN_LINE = len("Repo-filename: ")
+		const MinLine = len("Repo-filename: ")
 
 		// Ignore anything which isn't long enough or doesn't start with "Repo-"
-		if len(text) < MIN_LINE || !strings.HasPrefix(text, "Repo-") {
+		if len(text) < MinLine || !strings.HasPrefix(text, "Repo-") {
 			continue
 		}
 

--- a/services/process/client/client.go
+++ b/services/process/client/client.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package client provides the client interface for 'process'
 package client
 
 import (

--- a/services/process/process.go
+++ b/services/process/process.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package process defines the RPC interface for the sansshell Process actions.
 package process
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/process/process_grpcproxy.pb.go
+++ b/services/process/process_grpcproxy.pb.go
@@ -31,14 +31,16 @@ type processClientProxy struct {
 }
 
 // NewProcessClientProxy creates a ProcessClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewProcessClientProxy(cc *proxy.ProxyConn) ProcessClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewProcessClientProxy(cc *proxy.Conn) ProcessClientProxy {
 	return &processClientProxy{NewProcessClient(cc).(*processClient)}
 }
 
+// ListManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ListManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ListReply
 	Error error
@@ -49,7 +51,7 @@ type ListManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *processClientProxy) ListOneMany(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (<-chan *ListManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *ListManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -101,9 +103,11 @@ func (c *processClientProxy) ListOneMany(ctx context.Context, in *ListRequest, o
 	return ret, nil
 }
 
+// GetStacksManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type GetStacksManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *GetStacksReply
 	Error error
@@ -114,7 +118,7 @@ type GetStacksManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *processClientProxy) GetStacksOneMany(ctx context.Context, in *GetStacksRequest, opts ...grpc.CallOption) (<-chan *GetStacksManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *GetStacksManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -166,9 +170,11 @@ func (c *processClientProxy) GetStacksOneMany(ctx context.Context, in *GetStacks
 	return ret, nil
 }
 
+// GetJavaStacksManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type GetJavaStacksManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *GetJavaStacksReply
 	Error error
@@ -179,7 +185,7 @@ type GetJavaStacksManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *processClientProxy) GetJavaStacksOneMany(ctx context.Context, in *GetJavaStacksRequest, opts ...grpc.CallOption) (<-chan *GetJavaStacksManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *GetJavaStacksManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -231,9 +237,11 @@ func (c *processClientProxy) GetJavaStacksOneMany(ctx context.Context, in *GetJa
 	return ret, nil
 }
 
+// GetMemoryDumpManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type GetMemoryDumpManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *GetMemoryDumpReply
 	Error error
@@ -245,7 +253,7 @@ type Process_GetMemoryDumpClientProxy interface {
 }
 
 type processClientGetMemoryDumpClientProxy struct {
-	cc         *proxy.ProxyConn
+	cc         *proxy.Conn
 	directDone bool
 	grpc.ClientStream
 }
@@ -277,7 +285,7 @@ func (x *processClientGetMemoryDumpClientProxy) Recv() ([]*GetMemoryDumpManyResp
 		return ret, nil
 	}
 
-	m := []*proxy.ProxyRet{}
+	m := []*proxy.Ret{}
 	if err := x.ClientStream.RecvMsg(&m); err != nil {
 		return nil, err
 	}
@@ -307,7 +315,7 @@ func (c *processClientProxy) GetMemoryDumpOneMany(ctx context.Context, in *GetMe
 	if err != nil {
 		return nil, err
 	}
-	x := &processClientGetMemoryDumpClientProxy{c.cc.(*proxy.ProxyConn), false, stream}
+	x := &processClientGetMemoryDumpClientProxy{c.cc.(*proxy.Conn), false, stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}

--- a/services/process/server/process.go
+++ b/services/process/server/process.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'Process' service.
 package server
 
 import (
@@ -27,9 +28,9 @@ import (
 	"strings"
 
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/azureblob"
-	_ "gocloud.dev/blob/gcsblob"
-	_ "gocloud.dev/blob/s3blob"
+	_ "gocloud.dev/blob/azureblob" // Bring Azure blob support in.
+	_ "gocloud.dev/blob/gcsblob"   // Bring GCS blob support in.
+	_ "gocloud.dev/blob/s3blob"    // Bring S3 blob support in.
 
 	"github.com/Snowflake-Labs/sansshell/services"
 	pb "github.com/Snowflake-Labs/sansshell/services/process"

--- a/services/process/server/process_darwin_test.go
+++ b/services/process/server/process_darwin_test.go
@@ -39,6 +39,6 @@ var (
 	testdataPstackThreadsTextProto       = "./testdata/linux_pstack_threads.textproto"
 	testdataPstackThreadsBadThread       = "./testdata/linux_pstack_threads_bad_thread.txt"
 	testdataPstackThreadsBadThreadNumber = "./testdata/linux_pstack_threads_bad_thread_number.txt"
-	testdataPstackThreadsBadThreadId     = "./testdata/linux_pstack_threads_bad_thread_id.txt"
+	testdataPstackThreadsBadThreadID     = "./testdata/linux_pstack_threads_bad_thread_id.txt"
 	testdataPstackThreadsBadLwp          = "./testdata/linux_pstack_threads_bad_lwp.txt"
 )

--- a/services/process/server/process_linux.go
+++ b/services/process/server/process_linux.go
@@ -100,10 +100,10 @@ func parser(r io.Reader) (map[int64]*pb.ProcessEntry, error) {
 
 		// We know there are at least 28 fields but can be more
 		// since command could have spaces.
-		const FIELD_COUNT = 28
+		const FieldCount = 28
 
-		if len(fields) < FIELD_COUNT {
-			return nil, status.Errorf(codes.Internal, "invalid field count for line. Must be %d minimum. Input: %q", FIELD_COUNT, text)
+		if len(fields) < FieldCount {
+			return nil, status.Errorf(codes.Internal, "invalid field count for line. Must be %d minimum. Input: %q", FieldCount, text)
 		}
 
 		for _, f := range []struct {
@@ -277,11 +277,11 @@ func parser(r io.Reader) (map[int64]*pb.ProcessEntry, error) {
 		}
 
 		// Class and stat have to be direct parsed.
-		const SCHEDULE_CLASS = 18
-		const STATE = 20
+		const ScheduleClass = 18
+		const State = 20
 
 		// Class
-		switch fields[SCHEDULE_CLASS] {
+		switch fields[ScheduleClass] {
 		case "-":
 			out.SchedulingClass = pb.SchedulingClass_SCHEDULING_CLASS_NOT_REPORTED
 		case "TS":
@@ -305,7 +305,7 @@ func parser(r io.Reader) (map[int64]*pb.ProcessEntry, error) {
 		}
 
 		// State
-		switch fields[STATE][0] {
+		switch fields[State][0] {
 		case 'D':
 			out.State = pb.ProcessState_PROCESS_STATE_UNINTERRUPTIBLE_SLEEP
 		case 'R':
@@ -321,8 +321,8 @@ func parser(r io.Reader) (map[int64]*pb.ProcessEntry, error) {
 		}
 
 		// Now process any trailing symbols on State
-		for i := 1; i < len(fields[STATE]); i++ {
-			switch fields[STATE][i] {
+		for i := 1; i < len(fields[State]); i++ {
+			switch fields[State][i] {
 			case '<':
 				out.StateCode = append(out.StateCode, pb.ProcessStateCode_PROCESS_STATE_CODE_HIGH_PRIORITY)
 			case 'N':
@@ -342,7 +342,7 @@ func parser(r io.Reader) (map[int64]*pb.ProcessEntry, error) {
 
 		// Everything left is the command so gather it up, rejoin with spaces
 		// and we're done with this line.
-		out.Command = strings.Join(fields[FIELD_COUNT:], " ")
+		out.Command = strings.Join(fields[FieldCount:], " ")
 		entries[out.Pid] = out
 		out = &pb.ProcessEntry{}
 	}

--- a/services/process/server/process_linux_test.go
+++ b/services/process/server/process_linux_test.go
@@ -36,6 +36,6 @@ var (
 	testdataPstackThreadsTextProto       = "./testdata/linux_pstack_threads.textproto"
 	testdataPstackThreadsBadThread       = "./testdata/linux_pstack_threads_bad_thread.txt"
 	testdataPstackThreadsBadThreadNumber = "./testdata/linux_pstack_threads_bad_thread_number.txt"
-	testdataPstackThreadsBadThreadId     = "./testdata/linux_pstack_threads_bad_thread_id.txt"
+	testdataPstackThreadsBadThreadID     = "./testdata/linux_pstack_threads_bad_thread_id.txt"
 	testdataPstackThreadsBadLwp          = "./testdata/linux_pstack_threads_bad_lwp.txt"
 )

--- a/services/process/server/process_test.go
+++ b/services/process/server/process_test.go
@@ -375,7 +375,7 @@ func TestPstack(t *testing.T) {
 		{
 			name:    "Bad thread data - id",
 			command: testutil.ResolvePath(t, "cat"),
-			input:   testdataPstackThreadsBadThreadId,
+			input:   testdataPstackThreadsBadThreadID,
 			pid:     1,
 			wantErr: true,
 		},

--- a/services/service/client/client.go
+++ b/services/service/client/client.go
@@ -14,7 +14,7 @@
    under the License.
 */
 
-// package client provides the client interface for 'service'
+// Package client provides the client interface for 'service'
 package client
 
 import (

--- a/services/service/server/server.go
+++ b/services/service/server/server.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package server implements the sansshell 'Service' service.
 package server
 
 import (

--- a/services/service/service.go
+++ b/services/service/service.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package service defines the RPC interface for the sansshell Service actions.
 package service
 
 // To regenerate the proto headers if the .proto changes, just run go generate

--- a/services/service/service_grpcproxy.pb.go
+++ b/services/service/service_grpcproxy.pb.go
@@ -29,14 +29,16 @@ type serviceClientProxy struct {
 }
 
 // NewServiceClientProxy creates a ServiceClientProxy for use in proxied connections.
-// NOTE: This takes a ProxyConn instead of a generic ClientConnInterface as the methods here are only valid in ProxyConn contexts.
-func NewServiceClientProxy(cc *proxy.ProxyConn) ServiceClientProxy {
+// NOTE: This takes a proxy.Conn instead of a generic ClientConnInterface as the methods here are only valid in proxy.Conn contexts.
+func NewServiceClientProxy(cc *proxy.Conn) ServiceClientProxy {
 	return &serviceClientProxy{NewServiceClient(cc).(*serviceClient)}
 }
 
+// ListManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ListManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ListReply
 	Error error
@@ -47,7 +49,7 @@ type ListManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *serviceClientProxy) ListOneMany(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (<-chan *ListManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *ListManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -99,9 +101,11 @@ func (c *serviceClientProxy) ListOneMany(ctx context.Context, in *ListRequest, o
 	return ret, nil
 }
 
+// StatusManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type StatusManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *StatusReply
 	Error error
@@ -112,7 +116,7 @@ type StatusManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *serviceClientProxy) StatusOneMany(ctx context.Context, in *StatusRequest, opts ...grpc.CallOption) (<-chan *StatusManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *StatusManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {
@@ -164,9 +168,11 @@ func (c *serviceClientProxy) StatusOneMany(ctx context.Context, in *StatusReques
 	return ret, nil
 }
 
+// ActionManyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
 type ActionManyResponse struct {
 	Target string
-	// As targets can be duplicated this is the index into the slice passed to ProxyConn.
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
 	Index int
 	Resp  *ActionReply
 	Error error
@@ -177,7 +183,7 @@ type ActionManyResponse struct {
 //
 // NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
 func (c *serviceClientProxy) ActionOneMany(ctx context.Context, in *ActionRequest, opts ...grpc.CallOption) (<-chan *ActionManyResponse, error) {
-	conn := c.cc.(*proxy.ProxyConn)
+	conn := c.cc.(*proxy.Conn)
 	ret := make(chan *ActionManyResponse)
 	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
 	if len(conn.Targets) == 1 {

--- a/services/services.go
+++ b/services/services.go
@@ -14,6 +14,8 @@
    under the License.
 */
 
+// Package services provides functions to register and list all the
+// services contained in a sansshell gRPC server.
 package services
 
 import (
@@ -24,23 +26,25 @@ import (
 
 var (
 	mu          sync.RWMutex
-	rpcServices []SansShellRpcService
+	rpcServices []SansShellRPCService
 )
 
-type SansShellRpcService interface {
+// SansShellRPCService provides an interface for services to implement
+// to make them registerable in this package.
+type SansShellRPCService interface {
 	Register(*grpc.Server)
 }
 
 // RegisterSansShellService provides a mechanism for imported modules to
 // register themselves with a gRPC server.
-func RegisterSansShellService(s SansShellRpcService) {
+func RegisterSansShellService(s SansShellRPCService) {
 	mu.Lock()
 	defer mu.Unlock()
 	rpcServices = append(rpcServices, s)
 }
 
-// ListServices returns the list of registered serfvices.
-func ListServices() []SansShellRpcService {
+// ListServices returns the list of registered services.
+func ListServices() []SansShellRPCService {
 	mu.RLock()
 	defer mu.RUnlock()
 	return rpcServices

--- a/services/util/util_test.go
+++ b/services/util/util_test.go
@@ -108,7 +108,7 @@ func TestRunCommand(t *testing.T) {
 
 func TestTrimString(t *testing.T) {
 	b := &bytes.Buffer{}
-	for i := 0; i < 2*MAX_BUF; i++ {
+	for i := 0; i < 2*MaxBuf; i++ {
 		b.WriteByte('c')
 	}
 	w := TrimString(b.String())

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -14,7 +14,7 @@
    under the License.
 */
 
-// package telemetry contains code for emitting telemetry
+// Package telemetry contains code for emitting telemetry
 // from Sansshell processes.
 package telemetry
 

--- a/testing/testutil/testutil.go
+++ b/testing/testutil/testutil.go
@@ -14,6 +14,7 @@
    under the License.
 */
 
+// Package testutil provides many test helpers/assertions used to simplify common testing patterns.
 package testutil
 
 import (
@@ -37,7 +38,7 @@ func ResolvePath(t *testing.T, path string) string {
 	return binPath
 }
 
-// FataOnErr is a testing helper function to test and abort on an error.
+// FatalOnErr is a testing helper function to test and abort on an error.
 // Reduces 3 lines to 1 for common error checking.
 func FatalOnErr(op string, e error, t *testing.T) {
 	t.Helper()
@@ -46,7 +47,7 @@ func FatalOnErr(op string, e error, t *testing.T) {
 	}
 }
 
-// FataOnNoErr is a testing helper function to test and abort when we get no error.
+// FatalOnNoErr is a testing helper function to test and abort when we get no error.
 // Reduces 3 lines to 1 for common error checking.
 func FatalOnNoErr(op string, e error, t *testing.T) {
 	t.Helper()
@@ -78,69 +79,69 @@ func DiffErr(op string, resp interface{}, compare interface{}, t *testing.T, opt
 	}
 }
 
-// Need a null ClientStream for testing.
+// FakeClientStream provides a null ClientStream for testing.
 type FakeClientStream struct{}
 
-// See grpc.ClientStream
+// Header - see grpc.ClientStream
 func (*FakeClientStream) Header() (metadata.MD, error) {
 	return nil, errors.New("unimplemented")
 }
 
-// See grpc.ClientStream
+// Trailer - see grpc.ClientStream
 func (*FakeClientStream) Trailer() metadata.MD {
 	return nil
 }
 
-// See grpc.ClientStream
+// CloseSend - see grpc.ClientStream
 func (*FakeClientStream) CloseSend() error {
 	return errors.New("unimplemented")
 }
 
-// See grpc.ClientStream
+// Context - see grpc.ClientStream
 func (*FakeClientStream) Context() context.Context {
 	return context.Background()
 }
 
-// See grpc.ClientStream
+// SendMsg - see grpc.ClientStream
 func (*FakeClientStream) SendMsg(interface{}) error {
 	return errors.New("unimplemented")
 }
 
-// See grpc.ClientStream
+// RecvMsg - see grpc.ClientStream
 func (*FakeClientStream) RecvMsg(interface{}) error {
 	return errors.New("unimplemented")
 }
 
-// Need a null ServerStream for testing
+// FakeServerStream provides a null ServerStream for testing
 type FakeServerStream struct {
 	Ctx context.Context
 }
 
-// See grpc.ServerStream
+// SetHeader - see grpc.ServerStream
 func (*FakeServerStream) SetHeader(metadata.MD) error {
 	return errors.New("unimplemented")
 }
 
-// See grpc.ServerStream
+// SendHeader - see grpc.ServerStream
 func (*FakeServerStream) SendHeader(metadata.MD) error {
 	return errors.New("unimplemented")
 }
 
-// See grpc.ServerStream
+// SetTrailer - see grpc.ServerStream
 func (*FakeServerStream) SetTrailer(metadata.MD) {
 }
 
-// See grpc.ServerStream
+// Context - see grpc.ServerStream
 func (f *FakeServerStream) Context() context.Context {
 	return f.Ctx
 }
 
-// See grpc.ServerStream
+// SendMsg - see grpc.ServerStream
 func (*FakeServerStream) SendMsg(interface{}) error {
 	return errors.New("unimplemented")
 }
 
-// See grpc.ServerStream
+// RecvMsg - see grpc.ServerStream
 func (*FakeServerStream) RecvMsg(interface{}) error {
 	return errors.New("unimplemented")
 }


### PR DESCRIPTION
* Add package comments where missing.
* Cleanup bad comment style.
* Fix common naming (Id -> ID, etc)
* Document missing exported functions.
* Rename all caps constants except where it's mirroring a native constant.