### PR TITLE
Add a cert field to HostAuthInput 

### DIFF
--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -82,6 +82,9 @@ type HostAuthInput struct {
 	// The host address
 	Net *NetAuthInput `json:"net"`
 
+	// Information about the certificate served by the host, if any
+	Cert *CertAuthInput `json:"cert"`
+
 	// Information about the principal associated with the host, if any
 	Principal *PrincipalAuthInput `json:"principal"`
 }


### PR DESCRIPTION
So we can use a cert from the host to do policy checks potentially.

i.e. issuer of host cert == issuer of peer cert is most likely case