### PR TITLE
Enable opa future keywords

### DIFF
--- a/auth/opa/opa.go
+++ b/auth/opa/opa.go
@@ -85,7 +85,8 @@ func NewAuthzPolicy(ctx context.Context, policy string, opts ...Option) (*AuthzP
 	for _, opt := range opts {
 		opt.apply(options)
 	}
-	module, err := ast.ParseModule("sanshell-authz-policy.rego", policy)
+	parserOpts := ast.ParserOptions{FutureKeywords: []string{"in"}}
+	module, err := ast.ParseModuleWithOpts("sanshell-authz-policy.rego", policy, parserOpts)
 	if err != nil {
 		return nil, fmt.Errorf("policy parse error: %w", err)
 	}

--- a/auth/opa/opa_test.go
+++ b/auth/opa/opa_test.go
@@ -109,6 +109,10 @@ allow {
   input.foo = "baz"
   input.bar = "bazzle"
 }
+
+allow {
+  "okayOne" in input.group
+}
 `
 	ctx := context.Background()
 	policy, err := NewAuthzPolicy(ctx, policyString)
@@ -152,6 +156,18 @@ allow {
 			name:    "allowed case 2",
 			input:   map[string]string{"foo": "baz", "bar": "bazzle"},
 			allowed: true,
+			errFunc: expectNoError,
+		},
+		{
+			name:    "allowed case 3",
+			input:   map[string][]string{"group": []string{"okayOne", "okayTwo"}},
+			allowed: true,
+			errFunc: expectNoError,
+		},
+		{
+			name:    "in not matched",
+			input:   map[string][]string{"group": []string{"okayThree", "okayFour"}},
+			allowed: false,
 			errFunc: expectNoError,
 		},
 		{


### PR DESCRIPTION
This allows the use of the "in" keyword in Rego policies, and adds tests that demonstrate simplistic usage.