### PR TITLE
Add an extensions field in RPCAuthInput.

### DIFF
--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -52,7 +52,7 @@ type RPCAuthInput struct {
 	Host *HostAuthInput `json:"host"`
 
 	// Implementation specific extensions.
-	Extensions []interface{} `json:"extensions"`
+	Extensions json.RawMessage `json:"extensions"`
 }
 
 // PeerAuthInput contains policy-relevant information about an RPC peer.

--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -36,7 +36,7 @@ type RPCAuthInput struct {
 	// The GRPC method name, as '/Package.Service/Method'
 	Method string `json:"method"`
 
-	// The request protocol buffer, serialized as JSON
+	// The request protocol buffer, serialized as JSON.
 	Message json.RawMessage `json:"message"`
 
 	// The message type as 'Package.Message'
@@ -45,11 +45,14 @@ type RPCAuthInput struct {
 	// Raw grpc metdata associated with this call.
 	Metadata metadata.MD `json:"metadata"`
 
-	// Information about the calling peer, if available
+	// Information about the calling peer, if available.
 	Peer *PeerAuthInput `json:"peer"`
 
 	// Information about the host serving the RPC.
 	Host *HostAuthInput `json:"host"`
+
+	// Implementation specific extensions.
+	Extensions []interface{} `json:"extensions"`
 }
 
 // PeerAuthInput contains policy-relevant information about an RPC peer.

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -72,13 +72,9 @@ allow {
 }
 
 allow {
-  some i
-  input.extensions[i].key = "key1"
-}
-
-allow {
-  some i
+  some i, j
   input.extensions[i].value = 12345
+  input.extensions[j].key = "key1"
 }
 `
 
@@ -111,6 +107,17 @@ func TestAuthzHook(t *testing.T) {
 			}
 		}
 	}
+
+	extensions, err := json.Marshal([]interface{}{
+		&KeyValExtension{
+			Key: "key1",
+			Val: "val2",
+		},
+		&IntExtension{
+			Value: 12345,
+		},
+	})
+	testutil.FatalOnErr("json.Marshal extensions", err, t)
 
 	for _, tc := range []struct {
 		name    string
@@ -147,13 +154,7 @@ func TestAuthzHook(t *testing.T) {
 			input: &RPCAuthInput{},
 			hooks: []RPCAuthzHook{
 				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
-					input.Extensions = append(input.Extensions, &KeyValExtension{
-						Key: "key1",
-						Val: "val2",
-					},
-						&IntExtension{
-							Value: 12345,
-						})
+					input.Extensions = extensions
 					return nil
 				}),
 			},

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -71,6 +71,15 @@ allow {
   input.peer.principal.groups[i] = "admin_users"
 }
 
+allow {
+  some i
+  input.extensions[i].key = "key1"
+}
+
+allow {
+  some i
+  input.extensions[i].value = 12345
+}
 `
 
 type KeyValExtension struct {

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -73,6 +73,15 @@ allow {
 
 `
 
+type KeyValExtension struct {
+	Key string `json:"key"`
+	Val string `json:"val"`
+}
+
+type IntExtension struct {
+	Value int `json:"value"`
+}
+
 func TestAuthzHook(t *testing.T) {
 	ctx := context.Background()
 	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile))
@@ -119,6 +128,23 @@ func TestAuthzHook(t *testing.T) {
 				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					input.MessageType = "Foo.BazRequest"
+					return nil
+				}),
+			},
+			errFunc: wantStatusCode(codes.OK),
+		},
+		{
+			name:  "extension hook",
+			input: &RPCAuthInput{},
+			hooks: []RPCAuthzHook{
+				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+					input.Extensions = append(input.Extensions, &KeyValExtension{
+						Key: "key1",
+						Val: "val2",
+					},
+						&IntExtension{
+							Value: 12345,
+						})
 					return nil
 				}),
 			},


### PR DESCRIPTION
Allows implementation defined additions to auth input for passing into OPA for evaluation.

Add tests showing this works as expected.