### PR TITLE
Client side OPA policy implementation

### DIFF
--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -53,7 +53,7 @@ type RPCAuthzHook interface {
 
 // New creates a new Authorizer from an opa.AuthzPolicy. Any supplied authorization
 // hooks will be executed, in the order provided, on each policy evauluation.
-func New(policy *opa.AuthzPolicy, authzHooks ...RPCAuthzHook) *Authorizer {
+func New(policy *opa.AuthzPolicy, clientPolicy *opa.AuthzPolicy, authzHooks ...RPCAuthzHook) *Authorizer {
 	return &Authorizer{policy: policy, hooks: authzHooks}
 }
 
@@ -130,6 +130,11 @@ func (g *Authorizer) Authorize(ctx context.Context, req interface{}, info *grpc.
 		return nil, err
 	}
 	return handler(ctx, req)
+}
+
+// AuthorizeClient implements grpc.UnaryClientInterceptor
+func (g *Authorizer) AuthorizeClient(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return nil
 }
 
 // AuthorizeStream implements grpc.StreamServerInterceptor

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -31,7 +31,9 @@ import (
 	mtlsFlags "github.com/Snowflake-Labs/sansshell/auth/mtls/flags"
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/cmd/sanssh/client"
+	cmdUtil "github.com/Snowflake-Labs/sansshell/cmd/util"
 	"github.com/Snowflake-Labs/sansshell/services/util"
+	"github.com/go-logr/stdr"
 	"github.com/google/subcommands"
 	"google.golang.org/grpc/metadata"
 
@@ -60,11 +62,13 @@ var (
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
-	timeout       = flag.Duration("timeout", defaultTimeout, "How long to wait for the command to complete")
-	credSource    = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
-	outputsDir    = flag.String("output-dir", "", "If set defines a directory to emit output/errors from commands. Files will be generated based on target as destination/0 destination/0.error, etc.")
-	justification = flag.String("justification", "", "If non-empty will add the key '"+rpcauth.ReqJustKey+"' to the outgoing context Metadata to be passed along to the server for possible validation and logging.")
-	targetsFile   = flag.String("targets-file", "", "If set read the targets list line by line (as host[:port]) from the indicated file instead of using --targets (error if both flags are used). A blank port acts the same as --targets")
+	timeout          = flag.Duration("timeout", defaultTimeout, "How long to wait for the command to complete")
+	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
+	outputsDir       = flag.String("output-dir", "", "If set defines a directory to emit output/errors from commands. Files will be generated based on target as destination/0 destination/0.error, etc.")
+	justification    = flag.String("justification", "", "If non-empty will add the key '"+rpcauth.ReqJustKey+"' to the outgoing context Metadata to be passed along to the server for possible validation and logging.")
+	targetsFile      = flag.String("targets-file", "", "If set read the targets list line by line (as host[:port]) from the indicated file instead of using --targets (error if both flags are used). A blank port acts the same as --targets")
+	clientPolicyFlag = flag.String("client-policy", "", "OPA policy for outbound client actions.  If empty no policy is applied.")
+	clientPolicyFile = flag.String("client-policy-file", "", "Path to a file with a client OPA.  If empty uses --client-policy")
 
 	// targets will be bound to --targets for sending a single request to N nodes.
 	targetsFlag util.StringSliceFlag
@@ -130,14 +134,18 @@ func main() {
 			(*targetsFlag.Target)[i] = fmt.Sprintf("%s:%d", t, defaultTargetPort)
 		}
 	}
+	logOpts := log.Ldate | log.Ltime | log.Lshortfile
+	logger := stdr.New(log.New(os.Stderr, "", logOpts)).WithName("sanssh")
+	clientPolicy := cmdUtil.ChoosePolicy(logger, "", *clientPolicyFlag, *clientPolicyFile)
 
 	rs := client.RunState{
-		Proxy:      *proxyAddr,
-		Targets:    *targetsFlag.Target,
-		Outputs:    *outputsFlag.Target,
-		OutputsDir: *outputsDir,
-		CredSource: *credSource,
-		Timeout:    *timeout,
+		Proxy:        *proxyAddr,
+		Targets:      *targetsFlag.Target,
+		Outputs:      *outputsFlag.Target,
+		OutputsDir:   *outputsDir,
+		CredSource:   *credSource,
+		Timeout:      *timeout,
+		ClientPolicy: clientPolicy,
 	}
 	ctx := context.Background()
 	if *justification != "" {


### PR DESCRIPTION
grpc will guarentee you the other side of an MTLS passed authn (i.e. it's a validly signed cert) but not necessarily that it's the cert you expected to see.

Client side OPA allows validation of any cert field we desire to give authz for whether we really accept/trust the server to be who it claims to be.

Provide an example in the integration test of both passing and failing.

Plumb logging into sanssh (off by default without -v) to allow debugging