### PR TITLE
Add a jitter param to the basic server startup and plumb it into the main server

### DIFF
--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -61,6 +61,7 @@ var (
 	verbosity     = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate      = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")
 	justification = flag.Bool("justification", false, "If true then justification (which is logged and possibly validated) must be passed along in the client context Metadata with the key '"+rpcauth.ReqJustKey+"'")
+	jitter        = flag.Duration("jitter", 0, "If non-zero wait 1..N Duration before exiting on startup failure during server.Run. Allows for jitter on restart to avoid cascading failure.")
 )
 
 func main() {
@@ -83,11 +84,12 @@ func main() {
 	}
 
 	rs := server.RunState{
-		Logger:        logger,
-		CredSource:    *credSource,
-		Hostport:      *hostport,
-		Policy:        policy,
-		Justification: *justification,
+		Logger:             logger,
+		CredSource:         *credSource,
+		Hostport:           *hostport,
+		Policy:             policy,
+		Justification:      *justification,
+		JitterSleepOnError: *jitter,
 	}
 	server.Run(ctx, rs)
 }

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -479,6 +479,12 @@ echo "Testing policy validation for server"
 check_status $? /dev/null policy check failed for server
 
 echo
+echo "Testing jitter on failure for startup"
+./bin/sansshell-server --root-ca=./auth/mtls/testdata/root.pem --server-cert=./auth/mtls/testdata/leaf.pem --server-key=./auth/mtls/testdata/leaf.pem --policy-file=${LOGS}/policy --jitter=5s >&${LOGS}/server-jitter.log
+grep -E -q -e '"msg"="jitter" "error"="sleeping before exit" "sleep"="' ${LOGS}/server-jitter.log
+check_status $? /dev/null cant find log entry for jitter
+
+echo
 echo "Starting servers. Logs in ${LOGS}"
 ./bin/proxy-server --justification --root-ca=./auth/mtls/testdata/root.pem --server-cert=./auth/mtls/testdata/leaf.pem --server-key=./auth/mtls/testdata/leaf.key --client-cert=./auth/mtls/testdata/client.pem --client-key=./auth/mtls/testdata/client.key --policy-file=${LOGS}/policy >&${LOGS}/proxy.log &
 PROXY_PID=$!


### PR DESCRIPTION
The server will be deployed across a large swath of machines potentially.
If a large number of nodes start/restart at once we don't want thundering herd problems if they have credential loading issues (say a remote cred store).

So allow the user to plumb a jitter in to the server.Run which can use this before it exits.

Add integration test to prove it works.