### PR TITLE
Remove hard coded timeout on context.

### DIFF
--- a/services/healthcheck/client/client.go
+++ b/services/healthcheck/client/client.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/google/subcommands"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -75,8 +74,6 @@ func (p *validateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 	state := args[0].(*util.ExecuteState)
 	c := pb.NewHealthCheckClientProxy(state.Conn)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.OkOneMany(ctx, &emptypb.Empty{})
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.

--- a/services/sansshell/client/client.go
+++ b/services/sansshell/client/client.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/google/subcommands"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -86,8 +85,6 @@ func (s *setVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...
 	state := args[0].(*util.ExecuteState)
 	c := pb.NewLoggingClientProxy(state.Conn)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.SetVerbosityOneMany(ctx, &pb.SetVerbosityRequest{Level: int32(s.level)})
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
@@ -126,8 +123,6 @@ func (g *getVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...
 	state := args[0].(*util.ExecuteState)
 	c := pb.NewLoggingClientProxy(state.Conn)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.GetVerbosityOneMany(ctx, &emptypb.Empty{})
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
@@ -173,8 +168,6 @@ func (s *setProxyVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, arg
 	// Get a real connection to the proxy
 	c := pb.NewLoggingClient(state.Conn.Proxy())
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.SetVerbosity(ctx, &pb.SetVerbosityRequest{Level: int32(s.level)})
 	if err != nil {
 		fmt.Fprintf(state.Err[0], "Could not set proxy logging: %v\n", err)
@@ -205,8 +198,6 @@ func (g *getProxyVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, arg
 	// Get a real connection to the proxy
 	c := pb.NewLoggingClient(state.Conn.Proxy())
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.GetVerbosity(ctx, &emptypb.Empty{})
 	if err != nil {
 		fmt.Fprintf(state.Err[0], "Could not get proxy logging: %v\n", err)
@@ -230,8 +221,6 @@ func (s *versionCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 	state := args[0].(*util.ExecuteState)
 	c := pb.NewStateClientProxy(state.Conn)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.VersionOneMany(ctx, &emptypb.Empty{})
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
@@ -271,8 +260,6 @@ func (g *proxyVersionCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...
 	// Get a real connection to the proxy
 	c := pb.NewStateClient(state.Conn.Proxy())
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	resp, err := c.Version(ctx, &emptypb.Empty{})
 	if err != nil {
 		fmt.Fprintf(state.Err[0], "Could not get proxy version: %v\n", err)


### PR DESCRIPTION
If the incoming was lower than 30s this is ignored anyways I beleive. Plus the top level always sets one with a deadline.

Sansshell module obviously cargo culted from healthcheck module.