### PR TITLE
When the proxy connects to a client this is in a synch path and can abort N connections

### DIFF
--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -243,10 +243,12 @@ func NewTargetStream(ctx context.Context, target string, dialer TargetDialer, me
 	ctx, cancel := context.WithCancel(ctx)
 	conn, err := dialer.DialContext(ctx, target)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	clientStream, err := conn.NewStream(ctx, method.StreamDesc(), method.FullName())
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	ts := &TargetStream{

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -243,12 +243,10 @@ func NewTargetStream(ctx context.Context, target string, dialer TargetDialer, me
 	ctx, cancel := context.WithCancel(ctx)
 	conn, err := dialer.DialContext(ctx, target)
 	if err != nil {
-		cancel()
 		return nil, err
 	}
 	clientStream, err := conn.NewStream(ctx, method.StreamDesc(), method.FullName())
 	if err != nil {
-		cancel()
 		return nil, err
 	}
 	ts := &TargetStream{


### PR DESCRIPTION
If we send N StartStreams down and one times out to the context deadline and that deadline is < 20s (the default dial deadline) it will end up aborting the whole stream for all targets.

Instead we should push the Dial/NewStream into a go routine as well so the processing can dispatch N of these at once without backing up.

