### PR TITLE
Instead of flags sprinkled across modules export vars from each instead.

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -41,8 +41,11 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/localfile"
 	_ "github.com/Snowflake-Labs/sansshell/services/packages"
 	_ "github.com/Snowflake-Labs/sansshell/services/process"
-	ssserver "github.com/Snowflake-Labs/sansshell/services/sansshell/server"
+	_ "github.com/Snowflake-Labs/sansshell/services/sansshell"
 	_ "github.com/Snowflake-Labs/sansshell/services/service"
+
+	// Import the sansshell server code so we can use Version.
+	ssserver "github.com/Snowflake-Labs/sansshell/services/sansshell/server"
 )
 
 var (
@@ -62,6 +65,12 @@ var (
 )
 
 func init() {
+	flag.StringVar(&mtlsFlags.ClientCertFile, "client-cert", mtlsFlags.ClientCertFile, "Path to this client's x509 cert, PEM format")
+	flag.StringVar(&mtlsFlags.ClientKeyFile, "client-key", mtlsFlags.ClientKeyFile, "Path to this client's key")
+	flag.StringVar(&mtlsFlags.ServerCertFile, "server-cert", mtlsFlags.ServerCertFile, "Path to an x509 server cert, PEM format")
+	flag.StringVar(&mtlsFlags.ServerKeyFile, "server-key", mtlsFlags.ServerKeyFile, "Path to the server's TLS key")
+	flag.StringVar(&mtlsFlags.RootCAFile, "root-ca", mtlsFlags.RootCAFile, "The root of trust for remote identities, PEM format")
+
 	flag.BoolVar(&version, "version", false, "Returns the server built version from the sansshell server package")
 }
 

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -80,6 +80,12 @@ If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
 )
 
 func init() {
+	flag.StringVar(&mtlsFlags.ClientCertFile, "client-cert", mtlsFlags.ClientCertFile, "Path to this client's x509 cert, PEM format")
+	flag.StringVar(&mtlsFlags.ClientKeyFile, "client-key", mtlsFlags.ClientKeyFile, "Path to this client's key")
+	flag.StringVar(&mtlsFlags.ServerCertFile, "server-cert", mtlsFlags.ServerCertFile, "Path to an x509 server cert, PEM format")
+	flag.StringVar(&mtlsFlags.ServerKeyFile, "server-key", mtlsFlags.ServerKeyFile, "Path to the server's TLS key")
+	flag.StringVar(&mtlsFlags.RootCAFile, "root-ca", mtlsFlags.RootCAFile, "The root of trust for remote identities, PEM format")
+
 	// Setup an empty slice so it can be deref'd below regardless of user input.
 	outputsFlag.Target = &[]string{}
 	targetsFlag.Target = &[]string{}

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -45,12 +45,18 @@ import (
 	"github.com/Snowflake-Labs/sansshell/cmd/util"
 
 	// Import the server modules you want to expose, they automatically register
-	_ "github.com/Snowflake-Labs/sansshell/services/ansible/server"
+
+	// Ansible needs a real import to bind flags.
+	ansible "github.com/Snowflake-Labs/sansshell/services/ansible/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/exec/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/localfile/server"
-	_ "github.com/Snowflake-Labs/sansshell/services/packages/server"
-	_ "github.com/Snowflake-Labs/sansshell/services/process/server"
+
+	// Packages needs a real import to bind flags.
+	packages "github.com/Snowflake-Labs/sansshell/services/packages/server"
+	// Process needs a real import to bind flags.
+	process "github.com/Snowflake-Labs/sansshell/services/process/server"
+	// Sansshell server needs a real import to get at Version
 	ssserver "github.com/Snowflake-Labs/sansshell/services/sansshell/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/service/server"
 )
@@ -70,6 +76,22 @@ var (
 )
 
 func init() {
+	flag.StringVar(&mtlsFlags.ClientCertFile, "client-cert", mtlsFlags.ClientCertFile, "Path to this client's x509 cert, PEM format")
+	flag.StringVar(&mtlsFlags.ClientKeyFile, "client-key", mtlsFlags.ClientKeyFile, "Path to this client's key")
+	flag.StringVar(&mtlsFlags.ServerCertFile, "server-cert", mtlsFlags.ServerCertFile, "Path to an x509 server cert, PEM format")
+	flag.StringVar(&mtlsFlags.ServerKeyFile, "server-key", mtlsFlags.ServerKeyFile, "Path to the server's TLS key")
+	flag.StringVar(&mtlsFlags.RootCAFile, "root-ca", mtlsFlags.RootCAFile, "The root of trust for remote identities, PEM format")
+
+	flag.StringVar(&ansible.AnsiblePlaybookBin, "ansible_playbook_bin", ansible.AnsiblePlaybookBin, "Path to ansible-playbook binary")
+
+	flag.StringVar(&packages.YumBin, "yum-bin", packages.YumBin, "Path to yum binary")
+
+	flag.StringVar(&process.JstackBin, "jstack-bin", process.JstackBin, "Path to the jstack binary")
+	flag.StringVar(&process.JmapBin, "jmap-bin", process.JmapBin, "Path to the jmap binary")
+	flag.StringVar(&process.PsBin, "ps-bin", process.PsBin, "Path to the ps binary")
+	flag.StringVar(&process.PstackBin, "pstack-bin", process.PstackBin, "Path to the pstack binary")
+	flag.StringVar(&process.GcoreBin, "gcore-bin", process.GcoreBin, "Path to the gcore binary")
+
 	flag.BoolVar(&version, "version", false, "Returns the server built version from the sansshell server package")
 }
 

--- a/services/ansible/server/ansible_test.go
+++ b/services/ansible/server/ansible_test.go
@@ -72,7 +72,7 @@ func TestRun(t *testing.T) {
 
 	// Setup for tests where we use cat and pre-canned data
 	// to submit into the server.
-	savedAnsiblePlaybookBin := *ansiblePlaybookBin
+	savedAnsiblePlaybookBin := AnsiblePlaybookBin
 
 	savedCmdArgsTransform := cmdArgsTransform
 	cmdArgsTransform = func(input []string) []string {
@@ -81,7 +81,7 @@ func TestRun(t *testing.T) {
 		return []string{"/dev/null"}
 	}
 	t.Cleanup(func() {
-		*ansiblePlaybookBin = savedAnsiblePlaybookBin
+		AnsiblePlaybookBin = savedAnsiblePlaybookBin
 		cmdArgsTransform = savedCmdArgsTransform
 	})
 
@@ -108,6 +108,10 @@ func TestRun(t *testing.T) {
 			name:    "A non-absolute bin path",
 			bin:     "something",
 			path:    path,
+			wantErr: true,
+		},
+		{
+			name:    "no ansible binary",
 			wantErr: true,
 		},
 		{
@@ -186,7 +190,7 @@ func TestRun(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			*ansiblePlaybookBin = tc.bin
+			AnsiblePlaybookBin = tc.bin
 			cmdArgsTransform = func(input []string) []string {
 				return tc.args
 			}

--- a/services/packages/server/packages.go
+++ b/services/packages/server/packages.go
@@ -38,7 +38,10 @@ func genCmd(p pb.PackageSystem, m map[pb.PackageSystem][]string) ([]string, erro
 	var out []string
 	switch p {
 	case pb.PackageSystem_PACKAGE_SYSTEM_YUM:
-		out = append(out, *yumBin)
+		if YumBin == "" {
+			return nil, status.Errorf(codes.Unimplemented, "no support for yum")
+		}
+		out = append(out, YumBin)
 		out = append(out, m[p]...)
 	default:
 		return nil, status.Errorf(codes.Unimplemented, "no support for package system enum %d", p)

--- a/services/packages/server/packages_default.go
+++ b/services/packages/server/packages_default.go
@@ -19,8 +19,7 @@
 
 package server
 
-import (
-	"flag"
+var (
+	// YumBin is the location of the yum binary. On non-linux this is blank as it's likely unsupported.
+	YumBin string
 )
-
-var yumBin = flag.String("yum-bin", "false", "Path to yum binary (NOTE: no support on this platform)")

--- a/services/packages/server/packages_linux.go
+++ b/services/packages/server/packages_linux.go
@@ -19,8 +19,7 @@
 
 package server
 
-import (
-	"flag"
+var (
+	// YumBin is the location of the yum binary. Binding this to a flag is often useful.
+	YumBin = "/usr/bin/yum"
 )
-
-var yumBin = flag.String("yum-bin", "/usr/bin/yum", "Path to yum binary")

--- a/services/packages/server/packages_test.go
+++ b/services/packages/server/packages_test.go
@@ -150,10 +150,20 @@ func TestInstall(t *testing.T) {
 		Repo:    "somerepo",
 	}
 
-	// Test 1: A clean install. Validate we got expected output back.
+	savedYumBin := YumBin
+	t.Cleanup(func() {
+		YumBin = savedYumBin
+	})
 
+	// Test 1: Should fail on a blank yum
+	YumBin = ""
+	_, err = client.Install(ctx, req)
+	testutil.FatalOnNoErr("clean install request", err, t)
+
+	// Test 2: A clean install. Validate we got expected output back.
 	// This is assuming yum based installs for testing command builder.
-	wantCmdLine := fmt.Sprintf("%s install-nevra -y --enablerepo=somerepo package-1.2.3", *yumBin)
+	YumBin = "yum"
+	wantCmdLine := fmt.Sprintf("%s install-nevra -y --enablerepo=somerepo package-1.2.3", YumBin)
 
 	resp, err := client.Install(ctx, req)
 	testutil.FatalOnErr("clean install request", err, t)
@@ -165,7 +175,7 @@ func TestInstall(t *testing.T) {
 	}
 	t.Logf("clean install response: %+v", resp)
 
-	// Test 2: Permutations on bad commands/output.
+	// Test 3: Permutations on bad commands/output.
 	for _, tc := range []struct {
 		name     string
 		generate func(*pb.InstallRequest) ([]string, error)
@@ -364,11 +374,16 @@ func TestUpdate(t *testing.T) {
 		Repo:       "somerepo",
 	}
 
+	savedYumBin := YumBin
+	t.Cleanup(func() {
+		YumBin = savedYumBin
+	})
 	// Test 1: A clean install. Validate we got expected output back.
 
 	// This is assuming yum based installs for testing command builder.
-	wantValidateCmdLine := fmt.Sprintf("%s list installed package-0:1-1.2.3", *yumBin)
-	wantCmdLine := fmt.Sprintf("%s update-to -y --enablerepo=somerepo package-0:1-4.5.6", *yumBin)
+	YumBin = "yum"
+	wantValidateCmdLine := fmt.Sprintf("%s list installed package-0:1-1.2.3", YumBin)
+	wantCmdLine := fmt.Sprintf("%s update-to -y --enablerepo=somerepo package-0:1-4.5.6", YumBin)
 
 	resp, err := client.Update(ctx, req)
 	testutil.FatalOnErr("clean update request", err, t)
@@ -492,10 +507,15 @@ func TestListInstalled(t *testing.T) {
 	}
 	t.Log(err)
 
+	savedYumBin := YumBin
+	t.Cleanup(func() {
+		YumBin = savedYumBin
+	})
 	// Test 1: No options. Should pick yum w/o error and give back our list.
 
 	// This is assuming yum based installs for testing command builder.
-	wantCmdLine := fmt.Sprintf("%s list installed", *yumBin)
+	YumBin = "yum"
+	wantCmdLine := fmt.Sprintf("%s list installed", YumBin)
 
 	resp, err = client.ListInstalled(ctx, &pb.ListInstalledRequest{})
 	testutil.FatalOnErr("basic package list request", err, t)
@@ -607,10 +627,15 @@ func TestRepoList(t *testing.T) {
 	testutil.FatalOnNoErr(fmt.Sprintf("bad package enum - resp %v", resp), err, t)
 	t.Log(err)
 
+	savedYumBin := YumBin
+	t.Cleanup(func() {
+		YumBin = savedYumBin
+	})
 	// Test 1: No options. Should pick yum w/o error and give back our list.
 
 	// This is assuming yum based installs for testing command builder.
-	wantCmdLine := fmt.Sprintf("%s repoinfo all", *yumBin)
+	YumBin = "yum"
+	wantCmdLine := fmt.Sprintf("%s repoinfo all", YumBin)
 
 	resp, err = client.RepoList(ctx, &pb.RepoListRequest{})
 	testutil.FatalOnErr("basic repo list request", err, t)

--- a/services/process/server/process_darwin.go
+++ b/services/process/server/process_darwin.go
@@ -25,7 +25,6 @@ package server
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"strings"
@@ -36,9 +35,14 @@ import (
 )
 
 var (
-	psBin     = flag.String("ps-bin", "/bin/ps", "Path to the ps binary")
-	pstackBin = flag.String("pstack-bin", "", "Path to the pstack binary")
-	gcoreBin  = flag.String("gcore-bin", "", "Path to the gcore binary")
+	// PsBin is the location of the ps binary. Binding this to a flag is often useful.
+	PsBin = "/bin/ps"
+
+	// PstackBin is the location of the pstack binary. On OS/X this isn't supported.
+	PstackBin = ""
+
+	// GcoreBin is the location of the gcore binary. On OS/X this isn't supported.
+	GcoreBin = ""
 
 	// This is a var so we can replace for testing.
 	psOptions = func() []string {

--- a/services/process/server/process_default.go
+++ b/services/process/server/process_default.go
@@ -20,16 +20,20 @@
 package server
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"runtime"
 )
 
 var (
-	psBin     = flag.String("ps-bin", "", "Path to the ps binary")
-	pstackBin = flag.String("pstack-bin", "", "Path to the pstack binary")
-	gcoreBin  = flag.String("gcore-bin", "", "Path to the gcore binary")
+	// PsBin is the location of the ps binary. On non linux/OS/X this isn't supported.
+	PsBin = ""
+
+	// PstackBin is the location of the pstack binary. On non linux/OS/X this isn't supported.
+	PstackBin = ""
+
+	// GcoreBin is the location of the gcore binary. On non linux/OS/X this isn't supported.
+	GcoreBin = ""
 
 	psOptions = func() ([]string, error) {
 		return nil, fmt.Errorf("No support for OS %s", runtime.GOOS)

--- a/services/process/server/process_linux.go
+++ b/services/process/server/process_linux.go
@@ -25,7 +25,6 @@ package server
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"strings"
@@ -36,9 +35,14 @@ import (
 )
 
 var (
-	psBin     = flag.String("ps-bin", "/usr/bin/ps", "Path to the ps binary")
-	pstackBin = flag.String("pstack-bin", "/usr/bin/pstack", "Path to the pstack binary")
-	gcoreBin  = flag.String("gcore-bin", "/usr/bin/gcore", "Path to the gcore binary")
+	// PsBin is the location of the ps binary. Binding this to a flag is often useful.
+	PsBin = "/usr/bin/ps"
+
+	// PstackBin is the location of the pstack binary. Binding this to a flag is often useful.
+	PstackBin = "/usr/bin/pstack"
+
+	// GcoreBin is the location of the gcore binary. Binding this to a flag is often useful.
+	GcoreBin = "/usr/bin/gcore"
 
 	// This is a var so we can replace for testing.
 	psOptions = func() []string {


### PR DESCRIPTION
The in the binaries we can bind them to flags as needed.

This is a lot cleaner since flags can't conflict with each other and over time as we add modules this is bound to happen otherwise. With package vars you get a natural boundary that can't conflict.

Additionally some items will likely be duplicated too (i.e. where is the JVM binary?) and having each module attempt to create a unique flag vs one binding (flag.Func can do this for us) will be useful when scaling.

In the end this wasn't a lot of overall code change and caught a few bugs where empty flags would produce odd behavior so add some code and tests for that too.