### PR TITLE
Cleanup client error handling.

### DIFF
--- a/services/ansible/client/client.go
+++ b/services/ansible/client/client.go
@@ -112,7 +112,7 @@ func (a *playbookCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Run returned error: %v\n", err)
+			fmt.Fprintf(e, "All targets - Run returned error: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -122,6 +122,9 @@ func (a *playbookCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 		fmt.Fprintf(state.Out[r.Index], "Target: %s (%d)\n\n", r.Target, r.Index)
 		if r.Error != nil {
 			fmt.Fprintf(state.Err[r.Index], "Ansible for target %s (%d) returned error: %v\n", r.Target, r.Index, r.Error)
+			// If any target had errors it needs to be reported for that target but we still
+			// need to process responses off the channel. Final return code though should
+			// indicate something failed.
 			retCode = subcommands.ExitFailure
 			continue
 		}

--- a/services/fdb/client/client.go
+++ b/services/fdb/client/client.go
@@ -316,7 +316,7 @@ func runFDBCLI(ctx context.Context, c pb.CLIClientProxy, state *util.ExecuteStat
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "fdbcli %s error: %v\n", command, err)
+			fmt.Fprintf(e, "All targets - fdbcli %s error: %v\n", command, err)
 		}
 		return subcommands.ExitFailure
 	}

--- a/services/healthcheck/client/client.go
+++ b/services/healthcheck/client/client.go
@@ -78,7 +78,7 @@ func (p *validateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Could not healthcheck server: %v\n", err)
+			fmt.Fprintf(e, "All targets - could not healthcheck servers: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -87,6 +87,9 @@ func (p *validateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 	for r := range resp {
 		if r.Error != nil {
 			fmt.Fprintf(state.Err[r.Index], "Healthcheck for target %s (%d) returned error: %v\n", r.Target, r.Index, r.Error)
+			// If any target had errors it needs to be reported for that target but we still
+			// need to process responses off the channel. Final return code though should
+			// indicate something failed.
 			retCode = subcommands.ExitFailure
 			continue
 		}

--- a/services/packages/client/client.go
+++ b/services/packages/client/client.go
@@ -124,7 +124,7 @@ func (i *installCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Install returned error: %v\n", err)
+			fmt.Fprintf(e, "All targets - Install returned error: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -192,7 +192,7 @@ func (u *updateCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Update returned error: %v\n", err)
+			fmt.Fprintf(e, "All targets - Update returned error: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -241,7 +241,7 @@ func (l *listCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "List returned error: %v\n", err)
+			fmt.Fprintf(e, "All targets - List returned error: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -296,7 +296,7 @@ func (r *repoListCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Repo list returned error: %v\n", err)
+			fmt.Fprintf(e, "All targets - Repo list returned error: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}

--- a/services/sansshell/client/client.go
+++ b/services/sansshell/client/client.go
@@ -89,7 +89,7 @@ func (s *setVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Could not set logging: %v\n", err)
+			fmt.Fprintf(e, "All targets - Could not set logging: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -127,7 +127,7 @@ func (g *getVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Could not set logging: %v\n", err)
+			fmt.Fprintf(e, "All targets - Could not get logging: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -225,7 +225,7 @@ func (s *versionCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "Could not get version: %v\n", err)
+			fmt.Fprintf(e, "All targets - could not get version: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}

--- a/services/service/client/client.go
+++ b/services/service/client/client.go
@@ -151,7 +151,7 @@ func (a *actionCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "error executing %s: %v\n", as, err)
+			fmt.Fprintf(e, "All targets +error executing %s: %v\n", as, err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -227,7 +227,7 @@ func (s *statusCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "error executing 'status' for service %s: %v\n", serviceName, err)
+			fmt.Fprintf(e, "All targets - error executing 'status' for service %s: %v\n", serviceName, err)
 		}
 		return subcommands.ExitFailure
 	}
@@ -296,7 +296,7 @@ func (l *listCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 	if err != nil {
 		// Emit this to every error file as it's not specific to a given target.
 		for _, e := range state.Err {
-			fmt.Fprintf(e, "error executing 'list' for services: %v\n", err)
+			fmt.Fprintf(e, "All targets - error executing 'list' for services: %v\n", err)
 		}
 		return subcommands.ExitFailure
 	}


### PR DESCRIPTION
In unary cases just make sure top level errors are clear these are for all targets.

In streaming receive cases track the streams we've completed. This way errors on Recv() just apply to the remaining streams, not everything.

Avoids confusion