### PR TITLE
Fix flag parsing for setting verbosity 

### DIFF
--- a/services/fdb/client/client.go
+++ b/services/fdb/client/client.go
@@ -59,7 +59,7 @@ func processLog(state *util.ExecuteState, index int, log *pb.Log, openFiles map[
 	// This means we can only depend on the basename of the path which may have duplicates.
 	fn := filepath.Base(log.Filename)
 	if fn == "" {
-		fmt.Fprintf(state.Err[index], "RPC returned an invalid log structure: %+v", log)
+		fmt.Fprintf(state.Err[index], "RPC returned an invalid log structure: %+v\n", log)
 		return subcommands.ExitFailure, openFiles
 	}
 
@@ -85,7 +85,7 @@ func processLog(state *util.ExecuteState, index int, log *pb.Log, openFiles map[
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Fprintf(state.Err[index], "can't write logfile %s: %v", path, err)
+		fmt.Fprintf(state.Err[index], "can't write logfile %s: %v\n", path, err)
 		return subcommands.ExitFailure, openFiles
 	}
 	openFiles[log.Filename] = f

--- a/services/sansshell/client/client.go
+++ b/services/sansshell/client/client.go
@@ -72,18 +72,27 @@ type setVerbosityCmd struct {
 func (*setVerbosityCmd) Name() string     { return "set-verbosity" }
 func (*setVerbosityCmd) Synopsis() string { return "Set the logging verbosity level." }
 func (*setVerbosityCmd) Usage() string {
-	return `set-verbosity:
+	return `set-verbosity --verbosity=X
   Sends an integer logging level and returns the previous integer logging level.
 `
 }
 
 func (s *setVerbosityCmd) SetFlags(f *flag.FlagSet) {
-	f.IntVar(&s.level, "verbosity", 0, "The logging verbosity level to set")
+	f.IntVar(&s.level, "verbosity", -1, "The logging verbosity level to set")
 }
 
 func (s *setVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	state := args[0].(*util.ExecuteState)
 	c := pb.NewLoggingClientProxy(state.Conn)
+
+	if s.level < 0 {
+		fmt.Fprintln(os.Stderr, "--verbosity must be non-negative")
+		return subcommands.ExitFailure
+	}
+	if f.NArg() != 0 {
+		fmt.Fprint(os.Stderr, s.Usage())
+		return subcommands.ExitFailure
+	}
 
 	resp, err := c.SetVerbosityOneMany(ctx, &pb.SetVerbosityRequest{Level: int32(s.level)})
 	if err != nil {
@@ -151,20 +160,30 @@ type setProxyVerbosityCmd struct {
 func (*setProxyVerbosityCmd) Name() string     { return "set-proxy-verbosity" }
 func (*setProxyVerbosityCmd) Synopsis() string { return "Set the proxy logging verbosity level." }
 func (*setProxyVerbosityCmd) Usage() string {
-	return `set-proxy-verbosity:
-  Sends an integer logging level for the proxy server and returns the previous integer logging level.
+	return `set-proxy-verbosity --verbosity=X
+Sends an integer logging level for the proxy server and returns the previous integer logging level.
 `
 }
 
 func (s *setProxyVerbosityCmd) SetFlags(f *flag.FlagSet) {
-	f.IntVar(&s.level, "verbosity", 0, "The logging verbosity level to set")
+	f.IntVar(&s.level, "verbosity", -1, "The logging verbosity level to set")
 }
 
 func (s *setProxyVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	state := args[0].(*util.ExecuteState)
 	if len(state.Out) > 1 {
-		fmt.Fprintf(os.Stderr, "can't call proxy logging with multiple targets")
+		fmt.Fprintln(os.Stderr, "can't call proxy logging with multiple targets")
+		return subcommands.ExitFailure
 	}
+	if s.level < 0 {
+		fmt.Fprintln(os.Stderr, "--verbosity must be non-negative")
+		return subcommands.ExitFailure
+	}
+	if f.NArg() != 0 {
+		fmt.Fprint(os.Stderr, s.Usage())
+		return subcommands.ExitFailure
+	}
+
 	// Get a real connection to the proxy
 	c := pb.NewLoggingClient(state.Conn.Proxy())
 
@@ -193,7 +212,7 @@ func (*getProxyVerbosityCmd) SetFlags(f *flag.FlagSet) {}
 func (g *getProxyVerbosityCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	state := args[0].(*util.ExecuteState)
 	if len(state.Out) > 1 {
-		fmt.Fprintf(os.Stderr, "can't call proxy logging with multiple targets")
+		fmt.Fprintln(os.Stderr, "can't call proxy logging with multiple targets")
 	}
 	// Get a real connection to the proxy
 	c := pb.NewLoggingClient(state.Conn.Proxy())
@@ -255,7 +274,7 @@ func (*proxyVersionCmd) SetFlags(f *flag.FlagSet) {}
 func (g *proxyVersionCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	state := args[0].(*util.ExecuteState)
 	if len(state.Out) > 1 {
-		fmt.Fprintf(os.Stderr, "can't call proxy version with multiple targets")
+		fmt.Fprintln(os.Stderr, "can't call proxy version with multiple targets")
 	}
 	// Get a real connection to the proxy
 	c := pb.NewStateClient(state.Conn.Proxy())


### PR DESCRIPTION
If the default is 0 then it's possible to accidentally do

sanssh sansshell set-verbosity 1

and think it will work.

Instead default the flag to -1 and check we didn't pass other args.

Also cleanup 2 places in FDB client newlines on errors were forgotten