### PR TITLE
Add debugging support for cert reloads

### DIFF
--- a/auth/mtls/client.go
+++ b/auth/mtls/client.go
@@ -22,12 +22,14 @@ import (
 	"crypto/x509"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/grpc/credentials"
 )
 
 // LoadClientCredentials returns transport credentials for SansShell clients,
 // based on the provided `loaderName`
 func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
+	logger := logr.FromContextOrDiscard(ctx)
 	mtlsLoader, err := Loader(loaderName)
 	if err != nil {
 		return nil, err
@@ -41,6 +43,7 @@ func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.
 		loaderName: loaderName,
 		loader:     internalLoadClientCredentials,
 		mtlsLoader: mtlsLoader,
+		logger:     logger,
 	}
 	return wrapped, nil
 }

--- a/auth/mtls/client.go
+++ b/auth/mtls/client.go
@@ -49,6 +49,7 @@ func LoadClientCredentials(ctx context.Context, loaderName string) (credentials.
 }
 
 func internalLoadClientCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
+	logger := logr.FromContextOrDiscard(ctx)
 	loader, err := Loader(loaderName)
 	if err != nil {
 		return nil, err
@@ -58,10 +59,12 @@ func internalLoadClientCredentials(ctx context.Context, loaderName string) (cred
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("loading new client cert")
 	cert, err := loader.LoadClientCertificate(ctx)
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("loaded new client cert", "error", err)
 	return NewClientCredentials(cert, pool), nil
 }
 

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -79,6 +79,7 @@ func (w *WrappedTransportCredentials) checkRefresh() error {
 		fmt.Println("certs need reloading")
 		fmt.Printf("Wrapped: %+v\n", w)
 		newCreds, err := w.loader(context.Background(), w.loaderName)
+		fmt.Printf("newCreds: %+v err: %v\n", newCreds, err)
 		if err != nil {
 			return err
 		}

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -76,6 +76,8 @@ type WrappedTransportCredentials struct {
 
 func (w *WrappedTransportCredentials) checkRefresh() error {
 	if w.mtlsLoader.CertsRefreshed() {
+		fmt.Println("certs need reloading")
+		fmt.Printf("Wrapped: %+v\n", w)
 		newCreds, err := w.loader(context.Background(), w.loaderName)
 		if err != nil {
 			return err

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -79,13 +79,13 @@ type WrappedTransportCredentials struct {
 
 func (w *WrappedTransportCredentials) checkRefresh() error {
 	if w.mtlsLoader.CertsRefreshed() {
-		w.logger.Info("certs need reloading", "Wrapped: %+v\n", w)
+		w.logger.Info("certs need reloading")
 		// At least provide the logger we saved before we call into the loader
 		// or we lose all debugability.
 		ctx := context.Background()
 		ctx = logr.NewContext(ctx, w.logger)
 		newCreds, err := w.loader(ctx, w.loaderName)
-		w.logger.Info("newCreds", "creds", newCreds, "error", err)
+		w.logger.V(1).Info("newCreds", "creds", newCreds, "error", err)
 		if err != nil {
 			return err
 		}

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -67,7 +67,8 @@ type CredentialsLoader interface {
 }
 
 type WrappedTransportCredentials struct {
-	creds      credentials.TransportCredentials
+	mu         sync.Mutex
+	creds      credentials.TransportCredentials // GUARDED_BY(mu)
 	loaderName string
 	serverName string
 	mtlsLoader CredentialsLoader
@@ -83,6 +84,8 @@ func (w *WrappedTransportCredentials) checkRefresh() error {
 		if err != nil {
 			return err
 		}
+		w.mu.Lock()
+		defer w.mu.Unlock()
 		w.creds = newCreds
 		if w.serverName != "" {
 			return w.creds.OverrideServerName(w.serverName) //nolint:staticcheck

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -75,7 +75,7 @@ type WrappedTransportCredentials struct {
 	// are only ever set on startup which is single threaded by definition so don't
 	// need mutex protection.
 
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	creds      credentials.TransportCredentials // GUARDED_BY(mu)
 	loaderName string
 	serverName string // GUARDED_BY(mu)
@@ -111,8 +111,8 @@ func (w *WrappedTransportCredentials) ClientHandshake(ctx context.Context, s str
 	if err := w.checkRefresh(); err != nil {
 		return nil, nil, err
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	return w.creds.ClientHandshake(ctx, s, n)
 }
 
@@ -121,8 +121,8 @@ func (w *WrappedTransportCredentials) ServerHandshake(n net.Conn) (net.Conn, cre
 	if err := w.checkRefresh(); err != nil {
 		return nil, nil, err
 	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	return w.creds.ServerHandshake(n)
 }
 
@@ -130,8 +130,8 @@ func (w *WrappedTransportCredentials) ServerHandshake(n net.Conn) (net.Conn, cre
 func (w *WrappedTransportCredentials) Info() credentials.ProtocolInfo {
 	// We have no way to process an error with this API
 	_ = w.checkRefresh()
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	return w.creds.Info()
 }
 

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -49,6 +49,7 @@ func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.
 }
 
 func internalLoadServerCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
+	fmt.Printf("Loading creds for %s\n", loaderName)
 	loader, err := Loader(loaderName)
 	if err != nil {
 		return nil, err

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -52,20 +52,22 @@ func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.
 }
 
 func internalLoadServerCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
+	logger := logr.FromContextOrDiscard(ctx)
 	loader, err := Loader(loaderName)
 	if err != nil {
 		return nil, err
 	}
 
 	pool, err := loader.LoadClientCA(ctx)
-	fmt.Printf("pool: %T err: %v\n", pool, err)
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("loading new server cert")
 	cert, err := loader.LoadServerCertificate(ctx)
 	if err != nil {
 		return nil, err
 	}
+	logger.Info("loaded new server cert", "error", err)
 	return NewServerCredentials(cert, pool), nil
 }
 

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -51,15 +51,18 @@ func LoadServerCredentials(ctx context.Context, loaderName string) (credentials.
 func internalLoadServerCredentials(ctx context.Context, loaderName string) (credentials.TransportCredentials, error) {
 	fmt.Printf("Loading creds for %s\n", loaderName)
 	loader, err := Loader(loaderName)
+	fmt.Printf("loader: %+v err: %v\n", loader, err)
 	if err != nil {
 		return nil, err
 	}
 
 	pool, err := loader.LoadClientCA(ctx)
+	fmt.Printf("pool: %+v err: %v\n", pool, err)
 	if err != nil {
 		return nil, err
 	}
 	cert, err := loader.LoadServerCertificate(ctx)
+	fmt.Printf("cert: %+v err: %v\n", cert, err)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/mtls/server.go
+++ b/auth/mtls/server.go
@@ -57,12 +57,13 @@ func internalLoadServerCredentials(ctx context.Context, loaderName string) (cred
 	}
 
 	pool, err := loader.LoadClientCA(ctx)
-	fmt.Printf("pool: %+v err: %v\n", pool, err)
+	fmt.Printf("pool: %T err: %v\n", pool, err)
 	if err != nil {
 		return nil, err
 	}
 	cert, err := loader.LoadServerCertificate(ctx)
-	fmt.Printf("cert: %+v err: %v\n", cert, err)
+	c, _ := x509.ParseCertificate(cert.Certificate[0])
+	fmt.Printf("cert: %+v err: %v\n", c, err)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -71,7 +71,7 @@ If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
 	targetsFile      = flag.String("targets-file", "", "If set read the targets list line by line (as host[:port]) from the indicated file instead of using --targets (error if both flags are used). A blank port acts the same as --targets")
 	clientPolicyFlag = flag.String("client-policy", "", "OPA policy for outbound client actions.  If empty no policy is applied.")
 	clientPolicyFile = flag.String("client-policy-file", "", "Path to a file with a client OPA.  If empty uses --client-policy")
-	verbosity        = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
+	verbosity        = flag.Int("v", -1, "Verbosity level. > 0 indicates more extensive logging")
 
 	// targets will be bound to --targets for sending a single request to N nodes.
 	targetsFlag util.StringSliceFlag


### PR DESCRIPTION
Caching a context is a bad idea generally but we should pull any logger out for the incoming context and keep that in the wrapped Credential. This way we can log later and construct a logging context when we have no context except Background() to pass along.

Add logging around reload logic.

Technically a given credential can happen in N threads so anything writing here needs locking around it so add a mutex protecting access to it as we could panic if it's swapped while another thread is using it. Add some tests to double check this also.
