### PR TITLE
Add modules for each command which aren't built by default.

### DIFF
--- a/cmd/proxy-server/integration.go
+++ b/cmd/proxy-server/integration.go
@@ -1,0 +1,24 @@
+//go:build integration
+// +build integration
+
+/* Copyright (c) 2019 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package main
+
+import (
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/server"
+)

--- a/cmd/sanssh/integration.go
+++ b/cmd/sanssh/integration.go
@@ -1,0 +1,24 @@
+//go:build integration
+// +build integration
+
+/* Copyright (c) 2019 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package main
+
+import (
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/client"
+)

--- a/cmd/sansshell-server/integration.go
+++ b/cmd/sansshell-server/integration.go
@@ -1,0 +1,24 @@
+//go:build integration
+// +build integration
+
+/* Copyright (c) 2019 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package main
+
+import (
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/server"
+)

--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -21,7 +21,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
@@ -146,14 +145,13 @@ func Run(ctx context.Context, opts ...Option) {
 	}
 	for _, o := range opts {
 		if err := o.apply(rs); err != nil {
-			fmt.Fprintf(os.Stderr, "error applying option: %v\n", err)
+			rs.logger.Error(err, "error applying option")
 			os.Exit(1)
 		}
 	}
 
 	creds, err := mtls.LoadServerCredentials(ctx, rs.credSource)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error loading server creds: %v\n", err)
 		rs.logger.Error(err, "mtls.LoadServerCredentials", "credsource", rs.credSource)
 		os.Exit(1)
 	}
@@ -177,7 +175,6 @@ func Run(ctx context.Context, opts ...Option) {
 		serverOpts = append(serverOpts, server.WithStreamInterceptor(s))
 	}
 	if err := server.Serve(rs.hostport, serverOpts...); err != nil {
-		fmt.Fprintf(os.Stderr, "Can't serve: %v\n", err)
 		rs.logger.Error(err, "server.Serve", "hostport", rs.hostport)
 		os.Exit(1)
 	}

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -343,11 +343,11 @@ check_status $? /dev/null go vet
 echo
 echo "Running builds"
 echo
-go build -ldflags="-X github.com/Snowflake-Labs/sansshell/services/sansshell/server.Version=2p" -o bin/proxy-server ./cmd/proxy-server
+go build -tags integration -ldflags="-X github.com/Snowflake-Labs/sansshell/services/sansshell/server.Version=2p" -o bin/proxy-server ./cmd/proxy-server
 check_status $? /dev/null build proxy
-go build -o bin/sanssh ./cmd/sanssh
+go build -tags integration -o bin/sanssh ./cmd/sanssh
 check_status $? /dev/null build sanssh
-go build -ldflags="-X github.com/Snowflake-Labs/sansshell/services/sansshell/server.Version=2s" -o bin/sansshell-server ./cmd/sansshell-server
+go build -tags integration -ldflags="-X github.com/Snowflake-Labs/sansshell/services/sansshell/server.Version=2s" -o bin/sansshell-server ./cmd/sansshell-server
 check_status $? /dev/null build server
 
 # Test everything


### PR DESCRIPTION
Integration will build these which will result in FDB getting imported
for testing purposes. Would have caught recent issue with duplicate service
imports for instance.

Fix commands to emit version first before any other commands.

Also remove extra printing to stderr for errors now that logging is plumbed
in. Just noisy to print twice.