### PR TITLE
Fixes for client side issues

### DIFF
--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -108,9 +108,11 @@ func Run(ctx context.Context, rs RunState) {
 			fmt.Fprintf(os.Stderr, "%s: is not a directory\n", rs.OutputsDir)
 			os.Exit(1)
 		}
-		// Generate outputs from output-dir and the target count.
-		for i := range rs.Targets {
-			rs.Outputs = append(rs.Outputs, filepath.Join(rs.OutputsDir, fmt.Sprintf("%d", i)))
+		// Generate outputs from output-dir and the target count. The final filename is $output-dir/NUM-TARGET
+		// as often one wants to correlate specific output back to a given target and there's no guarentee the
+		// output will have this information in it. So instead supply it as metadata via the filename.
+		for i, t := range rs.Targets {
+			rs.Outputs = append(rs.Outputs, filepath.Join(rs.OutputsDir, fmt.Sprintf("%d-%s", i, t)))
 		}
 		dir = rs.OutputsDir
 	} else {

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -607,18 +607,17 @@ run_a_test false 1 exec run /usr/bin/echo Hello World
 # Test that outputs/errors go where expected and --output-dir works.
 mkdir -p ${LOGS}/exec-testdir
 ${SANSSH_PROXY} ${MULTI_TARGETS} --output-dir=${LOGS}/exec-testdir exec run /bin/sh -c "echo foo >&2"
-ls ${LOGS}/exec-testdir
 check_status $? /dev/null exec failed emitting to stderr
-if [ ! -f ${LOGS}/exec-testdir/0-localhost ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042 ]; then
+if [ ! -f ${LOGS}/exec-testdir/0-localhost:50042 ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042 ]; then
   check_status 1 /dev/null exec output files do not exist
 fi
-if [ -s ${LOGS}/exec-testdir/0-localhost ] || [ -s ${LOGS}/exec-testdir/1-localhost:50042 ]; then
+if [ -s ${LOGS}/exec-testdir/0-localhost:50042 ] || [ -s ${LOGS}/exec-testdir/1-localhost:50042 ]; then
   check_status 1 /dev/null exec output appeared in normal output files in ${LOGS}/exec-testdir
 fi
-if [ ! -f ${LOGS}/exec-testdir/0-localhost.error ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
+if [ ! -f ${LOGS}/exec-testdir/0-localhost:50042.error ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
   check_status 1 /dev/null exec error output files do not exist
 fi
-if [ ! -s ${LOGS}/exec-testdir/0-localhost.error ] || [ ! -s ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
+if [ ! -s ${LOGS}/exec-testdir/0-localhost:50042.error ] || [ ! -s ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
   check_status 1 /dev/null exec error output did not appear in ${LOGS}/exec-testdir error files
 fi
 

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -607,6 +607,7 @@ run_a_test false 1 exec run /usr/bin/echo Hello World
 # Test that outputs/errors go where expected and --output-dir works.
 mkdir -p ${LOGS}/exec-testdir
 ${SANSSH_PROXY} ${MULTI_TARGETS} --output-dir=${LOGS}/exec-testdir exec run /bin/sh -c "echo foo >&2"
+ls ${LOGS}/exec-testdir
 check_status $? /dev/null exec failed emitting to stderr
 if [ ! -f ${LOGS}/exec-testdir/0-localhost ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042 ]; then
   check_status 1 /dev/null exec output files do not exist

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -968,7 +968,7 @@ for i in "${LOGS}"/parallel/*; do
 done
 
 errors=$(cat "${LOGS}"/parallel/*.error | wc -l)
-healthy=$(cat "${LOGS}"/parallel/? | grep -c -h -E "Target.*healthy")
+healthy=$(cat "${LOGS}"/parallel/* | grep -c -h -E "Target.*healthy")
 if [ "${errors}" != 2 ]; then
   check_status 1 /dev/null 2 "targets should be unhealthy for various reasons"
 fi

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -608,10 +608,16 @@ run_a_test false 1 exec run /usr/bin/echo Hello World
 mkdir -p ${LOGS}/exec-testdir
 ${SANSSH_PROXY} ${MULTI_TARGETS} --output-dir=${LOGS}/exec-testdir exec run /bin/sh -c "echo foo >&2"
 check_status $? /dev/null exec failed emitting to stderr
-if [ -s ${LOGS}/exec-testdir/0 ] || [ -s ${LOGS}/exec-testdir/1 ]; then
+if [ ! -f ${LOGS}/exec-testdir/0-localhost ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042 ]; then
+  check_status 1 /dev/null exec output files do not exist
+fi
+if [ -s ${LOGS}/exec-testdir/0-localhost ] || [ -s ${LOGS}/exec-testdir/1-localhost:50042 ]; then
   check_status 1 /dev/null exec output appeared in normal output files in ${LOGS}/exec-testdir
 fi
-if [ ! -s ${LOGS}/exec-testdir/0.error ] || [ ! -s ${LOGS}/exec-testdir/1.error ]; then
+if [ ! -f ${LOGS}/exec-testdir/0-localhost.error ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
+  check_status 1 /dev/null exec error output files do not exist
+fi
+if [ ! -s ${LOGS}/exec-testdir/0-localhost.error ] || [ ! -s ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
   check_status 1 /dev/null exec error output did not appear in ${LOGS}/exec-testdir error files
 fi
 


### PR DESCRIPTION
**General** -

Rework how filenames work with --output-dir.

It will now be  NUM-TARGET for the filename instead of just a number. This allows metadata to indicate which file(s) go with which target(s).

**FDB** -

We get EOF on each client end so track and process that. Mirrors how other streaming client cases like Sum/Stat work.

