### PR TITLE
Add the ability to use the helper functions for starting proxy/server but also register your own services.

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -115,8 +115,8 @@ func main() {
 		server.WithCredSource(*credSource),
 		server.WithHostPort(*hostport),
 		server.WithJustification(*justification),
-		server.WithAdditionalRPCService(func(s *grpc.Server) { reflection.Register(s) }),
-		server.WithAdditionalRPCService(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
-		server.WithAdditionalRPCService(srv.Register),
+		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),
+		server.WithRawServerOption(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
+		server.WithRawServerOption(srv.Register),
 	)
 }

--- a/cmd/proxy-server/server/server.go
+++ b/cmd/proxy-server/server/server.go
@@ -28,12 +28,9 @@ import (
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/proxy/server"
-	ss "github.com/Snowflake-Labs/sansshell/services/sansshell/server"
 	"github.com/Snowflake-Labs/sansshell/telemetry"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
-	channelz "google.golang.org/grpc/channelz/service"
-	"google.golang.org/grpc/reflection"
 )
 
 // runState encapsulates all of the variable state needed
@@ -52,6 +49,7 @@ type runState struct {
 	streamInterceptors       []grpc.StreamServerInterceptor
 	streamClientInterceptors []grpc.StreamClientInterceptor
 	authzHooks               []rpcauth.RPCAuthzHook
+	services                 []func(*grpc.Server)
 }
 
 type Option interface {
@@ -174,6 +172,13 @@ func WithAuthzHook(hook rpcauth.RPCAuthzHook) Option {
 	})
 }
 
+func WithAdditionalRPCService(s func(*grpc.Server)) Option {
+	return optionFunc(func(r *runState) error {
+		r.services = append(r.services, s)
+		return nil
+	})
+}
+
 // Run takes the given context and RunState along with any authz hooks and starts up a sansshell proxy server
 // using the flags above to provide credentials. An address hook (based on the remote host) with always be added.
 // As this is intended to be called from main() it doesn't return errors and will instead exit on any errors.
@@ -273,12 +278,14 @@ func Run(ctx context.Context, opts ...Option) {
 	}
 	g := grpc.NewServer(serverOpts...)
 
+	// We always register the proxy.
 	server.Register(g)
-	reflection.Register(g)
-	channelz.RegisterChannelzServiceToServer(g)
-	// Create a an instance of logging for the proxy server itself.
-	s := &ss.Server{}
-	s.Register(g)
+
+	// Now loop over any other registered and call them.
+	for _, s := range rs.services {
+		s(g)
+	}
+
 	rs.logger.Info("initialized proxy service", "credsource", rs.credSource)
 	rs.logger.Info("serving..")
 

--- a/cmd/proxy-server/server/server.go
+++ b/cmd/proxy-server/server/server.go
@@ -172,7 +172,9 @@ func WithAuthzHook(hook rpcauth.RPCAuthzHook) Option {
 	})
 }
 
-func WithAdditionalRPCService(s func(*grpc.Server)) Option {
+// WithRawServerOption allows one access to the RPC Server object. Generally this is done to add additional
+// registration functions for RPC services to be done before starting the server.
+func WithRawServerOption(s func(*grpc.Server)) Option {
 	return optionFunc(func(r *runState) error {
 		r.services = append(r.services, s)
 		return nil

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -140,7 +140,7 @@ func main() {
 		server.WithHostPort(*hostport),
 		server.WithPolicy(policy),
 		server.WithJustification(*justification),
-		server.WithAdditionalRPCService(func(s *grpc.Server) { reflection.Register(s) }),
-		server.WithAdditionalRPCService(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
+		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),
+		server.WithRawServerOption(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
 	)
 }

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -31,6 +31,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
+	"google.golang.org/grpc"
+	channelz "google.golang.org/grpc/channelz/service"
+	"google.golang.org/grpc/reflection"
 
 	_ "gocloud.dev/blob/azureblob" // Pull in Azure blob support
 	_ "gocloud.dev/blob/fileblob"  // Pull in file blob support
@@ -137,5 +140,7 @@ func main() {
 		server.WithHostPort(*hostport),
 		server.WithPolicy(policy),
 		server.WithJustification(*justification),
+		server.WithAdditionalRPCService(func(s *grpc.Server) { reflection.Register(s) }),
+		server.WithAdditionalRPCService(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
 	)
 }

--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -138,10 +138,9 @@ func WithAuthzHook(hook rpcauth.RPCAuthzHook) Option {
 	})
 }
 
-// WithAdditionalRPCService adds additional registration functions for RPC services
-// to be done before starting the sansshell server. The services registered via blank imports
-// are always registered.
-func WithAdditionalRPCService(s func(*grpc.Server)) Option {
+// WithRawServerOption allows one access to the RPC Server object. Generally this is done to add additional
+// registration functions for RPC services to be done before starting the server.
+func WithRawServerOption(s func(*grpc.Server)) Option {
 	return optionFunc(func(r *runState) error {
 		r.services = append(r.services, s)
 		return nil
@@ -186,7 +185,7 @@ func Run(ctx context.Context, opts ...Option) {
 		serverOpts = append(serverOpts, server.WithStreamInterceptor(s))
 	}
 	for _, s := range rs.services {
-		serverOpts = append(serverOpts, server.WithAdditionalRPCService(s))
+		serverOpts = append(serverOpts, server.WithRawServerOption(s))
 	}
 	if err := server.Serve(rs.hostport, serverOpts...); err != nil {
 		rs.logger.Error(err, "server.Serve", "hostport", rs.hostport)

--- a/server/server.go
+++ b/server/server.go
@@ -109,10 +109,9 @@ func WithStreamInterceptor(stream grpc.StreamServerInterceptor) Option {
 	})
 }
 
-// WithAdditionalRPCService adds additional registration functions for RPC services
-// to be done before starting the server. The services listed from services.ListServices() are
-// always registered.
-func WithAdditionalRPCService(s func(*grpc.Server)) Option {
+// WithRawServerOption allows one access to the RPC Server object. Generally this is done to add additional
+// registration functions for RPC services to be done before starting the server.
+func WithRawServerOption(s func(*grpc.Server)) Option {
 	return optionFunc(func(r *serveSetup) error {
 		r.services = append(r.services, s)
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
-	channelz "google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/services"
@@ -49,6 +47,7 @@ type serveSetup struct {
 	authzHooks         []rpcauth.RPCAuthzHook
 	unaryInterceptors  []grpc.UnaryServerInterceptor
 	streamInterceptors []grpc.StreamServerInterceptor
+	services           []func(*grpc.Server)
 }
 
 type Option interface {
@@ -106,6 +105,16 @@ func WithUnaryInterceptor(unary grpc.UnaryServerInterceptor) Option {
 func WithStreamInterceptor(stream grpc.StreamServerInterceptor) Option {
 	return optionFunc(func(s *serveSetup) error {
 		s.streamInterceptors = append(s.streamInterceptors, stream)
+		return nil
+	})
+}
+
+// WithAdditionalRPCService adds additional registration functions for RPC services
+// to be done before starting the server. The services listed from services.ListServices() are
+// always registered.
+func WithAdditionalRPCService(s func(*grpc.Server)) Option {
+	return optionFunc(func(r *serveSetup) error {
+		r.services = append(r.services, s)
 		return nil
 	})
 }
@@ -172,12 +181,19 @@ func BuildServer(opts ...Option) (*grpc.Server, error) {
 		grpc.ChainUnaryInterceptor(unary...),
 		grpc.ChainStreamInterceptor(streaming...),
 	}
-	s := grpc.NewServer(serverOpts...)
-	reflection.Register(s)
-	channelz.RegisterChannelzServiceToServer(s)
 
+	s := grpc.NewServer(serverOpts...)
+
+	// Always register anything which is in the list as it was pulled in there
+	// via import and intended.
 	for _, sansShellService := range services.ListServices() {
 		sansShellService.Register(s)
 	}
+
+	// Now loop over any other registered and call them.
+	for _, srv := range ss.services {
+		srv(s)
+	}
+
 	return s, nil
 }

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -778,8 +778,8 @@ check_status $? /dev/null long list dir wrong. 2nd line should start with drwx -
 
 # Skip if on github (we assume yum, no apt support yet)
 if [ -z "${ON_GITHUB}" ]; then
-  run_a_test false 10 packages install --name=zziplib --version=0:0.13.62-12.el7.x86_64
-  run_a_test false 10 packages update --name=ansible --old_version=0:2.9.27-1.el7.noarch --new_version=0:2.9.27-1.el7.noarch
+  run_a_test false 5 packages install --name=zziplib --version=0:0.13.62-12.el7.x86_64
+  run_a_test false 5 packages update --name=ansible --old_version=0:2.9.27-1.el7.noarch --new_version=0:2.9.27-1.el7.noarch
   run_a_test false 50 packages list
   run_a_test false 50 packages repolist --verbose
 else


### PR DESCRIPTION
Create option variants to register arbitrary RPC services against the RPC server that's created.

Move channelz/reflection/etc up to the main() function. This way users aren't forced to inherit these
services unless they want them. Also means users can add their own arbitrary RPC services
to the server as well.