### PR TITLE
Fix rpcauth for proxy to properly include the peer we're connecting to

### DIFF
--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -298,6 +298,8 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			if err == io.EOF {
 				return nil
 			}
+			peerInfo, _ = peer.FromContext(grpcStream.Context())
+			s.logger.Info("peer2", "info", peerInfo.Addr.String())
 			// Otherwise, this is the 'final' error. The underlying
 			// stream will be torn down automatically, but we
 			// can return the error here, where it will be returned

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -277,7 +277,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			authinput.Host = &rpcauth.HostAuthInput{
 				Net: streamPeerInfo.Net,
 			}
-
+			s.logger.Info("authinput", "input", authinput)
 			// If authz fails, close immediately with an error
 			if err := s.authorizer.Eval(ctx, authinput); err != nil {
 				s.CloseWith(err)

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -206,7 +206,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			s.cancelFunc()
 			return err
 		}
-		grpcStream, err := s.grpcConn.NewStream(s.ctx, s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
+		grpcStream, err := s.grpcConn.NewStream(context.Background(), s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
 		if err != nil {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -275,6 +275,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				return err
 			}
 			peerInfo, ok := peer.FromContext(grpcStream.Context())
+			s.logger.Info("peer", "info", peerInfo.Addr.String())
 			if ok {
 				authinput.Host = &rpcauth.HostAuthInput{
 					Net: rpcauth.NetInputFromAddr(peerInfo.Addr),

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -222,6 +222,8 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			for {
 				msg := s.serviceMethod.NewReply()
 				err := grpcStream.RecvMsg(msg)
+				peerInfo, _ := peer.FromContext(grpcStream.Context())
+				s.logger.Info("rec peer", "info", peerInfo.Addr.String())
 				if err == io.EOF {
 					return nil
 				}

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -274,6 +274,10 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				s.CloseWith(err)
 				return err
 			}
+
+			// The returned peer info from context (either ours or the stream)
+			// is always the remote peer calling into the proxy. So craft up the
+			// host information directly from the target we have.
 			addr, err := net.ResolveTCPAddr("tcp", s.target)
 			if err == nil {
 				authinput.Host = &rpcauth.HostAuthInput{
@@ -284,7 +288,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 					},
 				}
 			}
-			s.logger.Info("authinput", "input", authinput)
+
 			// If authz fails, close immediately with an error
 			if err := s.authorizer.Eval(ctx, authinput); err != nil {
 				s.CloseWith(err)

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -302,8 +301,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			if err == io.EOF {
 				return nil
 			}
-			peerInfo, _ = peer.FromContext(grpcStream.Context())
-			s.logger.Info("peer2", "info", peerInfo.Addr.String())
+
 			// Otherwise, this is the 'final' error. The underlying
 			// stream will be torn down automatically, but we
 			// can return the error here, where it will be returned

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -275,7 +275,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				return err
 			}
 			addr, err := net.ResolveTCPAddr("tcp", s.target)
-			if err != nil {
+			if err == nil {
 				authinput.Host = &rpcauth.HostAuthInput{
 					Net: &rpcauth.NetAuthInput{
 						Network: "tcp",


### PR DESCRIPTION
The returned peer info from context (either ours or the stream)
is always the remote peer calling into the proxy. So craft up the
host information directly from the target we have.

This isn't perfect as it's not a resolved IP but it's better than nothing (which is effectively today).

On a stream you cannot call Context() before Recv() or Header() happen. Which on a unary call is effectively never so being able to check policy against the peer needs this.
