### PR TITLE
Fix JSON logging of RPCAuthInput

### DIFF
--- a/auth/opa/rpcauth/hooks.go
+++ b/auth/opa/rpcauth/hooks.go
@@ -58,7 +58,7 @@ func (c *conditionalHook) Hook(ctx context.Context, input *RPCAuthInput) error {
 
 // HostNetHook returns an RPCAuthzHook that sets host networking information.
 func HostNetHook(addr net.Addr) RPCAuthzHook {
-	return RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+	return RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 		if input.Host == nil {
 			input.Host = &HostAuthInput{}
 		}
@@ -82,7 +82,7 @@ var (
 // that validates if justification was included. If it is required and passes the optional validation function
 // it will return nil, otherwise an error.
 func JustificationHook(justificationFunc func(string) error) RPCAuthzHook {
-	return RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+	return RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 		// See if we got any metadata and if it contains the justification
 		var j string
 		v := input.Metadata[ReqJustKey]

--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -55,6 +55,33 @@ type RPCAuthInput struct {
 	Extensions json.RawMessage `json:"extensions"`
 }
 
+type RPCAuthInputForLogging struct {
+	Method      string         `json:"method"`
+	Message     string         `json:"message"`
+	MessageType string         `json:"type"`
+	Metadata    metadata.MD    `json:"metadata"`
+	Peer        *PeerAuthInput `json:"peer"`
+	Host        *HostAuthInput `json:"host"`
+	Extensions  string         `json:"extensions"`
+}
+
+func (r RPCAuthInput) MarshalLog() interface{} {
+	// Transform for logging by forcing the types
+	// for raw JSON into string. Otherwise logr
+	// will print them as strings of bytes. If we
+	// cast to string for the whole object then
+	// we end up with string escaping.
+	return RPCAuthInputForLogging{
+		Method:      r.Method,
+		Message:     string(r.Message),
+		MessageType: r.MessageType,
+		Metadata:    r.Metadata,
+		Peer:        r.Peer,
+		Host:        r.Host,
+		Extensions:  string(r.Extensions),
+	}
+}
+
 // PeerAuthInput contains policy-relevant information about an RPC peer.
 type PeerAuthInput struct {
 	// Network information about the peer

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -20,7 +20,6 @@ package rpcauth
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -81,12 +80,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	if input != nil {
 		if logger.V(2).Enabled() {
-			b, err := json.Marshal(input)
-			if err != nil {
-				logger.V(2).Info("marshal", "can't marshal input", err)
-			} else {
-				logger.V(2).Info("evaluating authz policy", "input", string(b))
-			}
+			logger.V(2).Info("evaluating authz policy", "input", input)
 		}
 	}
 	if input == nil {
@@ -102,12 +96,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		}
 	}
 	if logger.V(1).Enabled() {
-		_, err := json.Marshal(input)
-		if err != nil {
-			logger.V(1).Info("marshal", "can't marshal input", err)
-		} else {
-			logger.V(1).Info("evaluating authz policy post hooks", "input", input)
-		}
+		logger.V(1).Info("evaluating authz policy post hooks", "input", input)
 	}
 	allowed, err := g.policy.Eval(ctx, input)
 	if err != nil {

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -85,7 +85,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			if err != nil {
 				logger.V(2).Info("marshal", "can't marshal input", err)
 			} else {
-				logger.V(2).Info("evaluating authz policy", "input", string(b))
+				logger.V(2).Info("evaluating authz policy", "input", b)
 			}
 		}
 	}
@@ -106,7 +106,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		if err != nil {
 			logger.V(1).Info("marshal", "can't marshal input", err)
 		} else {
-			logger.V(1).Info("evaluating authz policy post hooks", "input", string(b))
+			logger.V(1).Info("evaluating authz policy post hooks", "input", b)
 		}
 	}
 	allowed, err := g.policy.Eval(ctx, input)

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -19,7 +19,6 @@
 package rpcauth
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 
@@ -86,9 +85,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			if err != nil {
 				logger.V(2).Info("marshal", "can't marshal input", err)
 			} else {
-				buf := &bytes.Buffer{}
-				buf.Write(b)
-				logger.V(2).Info("evaluating authz policy", "input", input)
+				logger.V(2).Info("evaluating authz policy", "input", string(b))
 			}
 		}
 	}
@@ -109,9 +106,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		if err != nil {
 			logger.V(1).Info("marshal", "can't marshal input", err)
 		} else {
-			buf := &bytes.Buffer{}
-			buf.Write(b)
-			logger.V(1).Info("evaluating authz policy post hooks", "input", input)
+			logger.V(1).Info("evaluating authz policy post hooks", "input", string(b))
 		}
 	}
 	allowed, err := g.policy.Eval(ctx, input)

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -102,11 +102,11 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		}
 	}
 	if logger.V(1).Enabled() {
-		b, err := json.Marshal(input)
+		_, err := json.Marshal(input)
 		if err != nil {
 			logger.V(1).Info("marshal", "can't marshal input", err)
 		} else {
-			logger.V(1).Info("evaluating authz policy post hooks", "input", string(b))
+			logger.V(1).Info("evaluating authz policy post hooks", "input", input)
 		}
 	}
 	allowed, err := g.policy.Eval(ctx, input)

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -19,6 +19,7 @@
 package rpcauth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 
@@ -85,7 +86,9 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			if err != nil {
 				logger.V(2).Info("marshal", "can't marshal input", err)
 			} else {
-				logger.V(2).Info("evaluating authz policy", "input", b)
+				buf := &bytes.Buffer{}
+				buf.Write(b)
+				logger.V(2).Info("evaluating authz policy", "input", buf.String())
 			}
 		}
 	}
@@ -106,7 +109,9 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		if err != nil {
 			logger.V(1).Info("marshal", "can't marshal input", err)
 		} else {
-			logger.V(1).Info("evaluating authz policy post hooks", "input", b)
+			buf := &bytes.Buffer{}
+			buf.Write(b)
+			logger.V(1).Info("evaluating authz policy post hooks", "input", buf.String())
 		}
 	}
 	allowed, err := g.policy.Eval(ctx, input)

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -88,7 +88,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			} else {
 				buf := &bytes.Buffer{}
 				buf.Write(b)
-				logger.V(2).Info("evaluating authz policy", "input", buf.String())
+				logger.V(2).Info("evaluating authz policy", "input", input)
 			}
 		}
 	}
@@ -111,7 +111,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		} else {
 			buf := &bytes.Buffer{}
 			buf.Write(b)
-			logger.V(1).Info("evaluating authz policy post hooks", "input", buf.String())
+			logger.V(1).Info("evaluating authz policy post hooks", "input", input)
 		}
 	}
 	allowed, err := g.policy.Eval(ctx, input)

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -141,7 +141,7 @@ func TestAuthzHook(t *testing.T) {
 			name:  "single hook, create allow",
 			input: &RPCAuthInput{},
 			hooks: []RPCAuthzHook{
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					input.MessageType = "Foo.BazRequest"
 					return nil
@@ -153,7 +153,7 @@ func TestAuthzHook(t *testing.T) {
 			name:  "extension hook",
 			input: &RPCAuthInput{},
 			hooks: []RPCAuthzHook{
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Extensions = extensions
 					return nil
 				}),
@@ -164,11 +164,11 @@ func TestAuthzHook(t *testing.T) {
 			name:  "multiple hooks, create allow",
 			input: &RPCAuthInput{},
 			hooks: []RPCAuthzHook{
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					return nil
 				}),
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.MessageType = "Foo.BazRequest"
 					return nil
 				}),
@@ -226,12 +226,12 @@ func TestAuthzHook(t *testing.T) {
 			name:  "hook ordering",
 			input: &RPCAuthInput{},
 			hooks: []RPCAuthzHook{
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Method = "/Foo.Bar/Baz"
 					input.MessageType = "Foo.BarRequest"
 					return nil
 				}),
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.MessageType = "Foo.BazRequest"
 					return nil
 				}),
@@ -242,7 +242,7 @@ func TestAuthzHook(t *testing.T) {
 			name:  "synthesize data, allow",
 			input: &RPCAuthInput{Method: "/Foo.Bar/Foo"},
 			hooks: []RPCAuthzHook{
-				RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					if input.Peer == nil {
 						input.Peer = &PeerAuthInput{
 							Principal: &PrincipalAuthInput{
@@ -321,7 +321,7 @@ func TestAuthzHook(t *testing.T) {
 			input: &RPCAuthInput{Method: "/Some.Random/Method"},
 			// Set principal to admin if method = "/Some.Random/Method"
 			hooks: []RPCAuthzHook{
-				HookIf(RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				HookIf(RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Peer = &PeerAuthInput{
 						Principal: &PrincipalAuthInput{
 							ID: "admin@foo",
@@ -339,7 +339,7 @@ func TestAuthzHook(t *testing.T) {
 			input: &RPCAuthInput{Method: "/Some.Other/Method"},
 			// Set principal to admin if method = "/Some.Random/Method"
 			hooks: []RPCAuthzHook{
-				HookIf(RPCAuthzHookFunc(func(ctx context.Context, input *RPCAuthInput) error {
+				HookIf(RPCAuthzHookFunc(func(_ context.Context, input *RPCAuthInput) error {
 					input.Peer = &PeerAuthInput{
 						Principal: &PrincipalAuthInput{
 							ID: "admin@foo",


### PR DESCRIPTION
Restructure how we log an RPCAuthInput.

We can't just json marshal and then stringify it into the logs. It gets escaped then which makes it not workable if you assume this entry is JSON (which it should be).

To get the 2 fields which are already marshaled we'd like to read those as logr will print slices as [byte, byte, ...] which isn't useful.

So maintain a mirror type of RPCAuthInput where the 2 marshal'd fields are strings and then copy everything over and return that struct for logging purposes.

It does mean input.message is escaped still but that's easier than a byte stream and the rest of the log is fully parseable JSON now.

Long term we should likely write our own logr implementation where we can disable escaping on a per field basis.