### PR TITLE
Fix ordering for yum commands.

### DIFF
--- a/services/packages/server/packages.go
+++ b/services/packages/server/packages.go
@@ -56,11 +56,12 @@ type repoData struct {
 
 // Optionally add the repo arg and then append the full package name to the list.
 func addRepoAndPackage(out []string, p pb.PackageSystem, name string, version string, repos *repoData) []string {
-	if repos.enable != "" && p == pb.PackageSystem_PACKAGE_SYSTEM_YUM {
-		out = append(out, fmt.Sprintf("--enablerepo=%s", repos.enable))
-	}
+	// Disable must go first since it'll over enable otherwise and leave no repos potentially
 	if repos.disable != "" && p == pb.PackageSystem_PACKAGE_SYSTEM_YUM {
 		out = append(out, fmt.Sprintf("--disablerepo=%s", repos.disable))
+	}
+	if repos.enable != "" && p == pb.PackageSystem_PACKAGE_SYSTEM_YUM {
+		out = append(out, fmt.Sprintf("--enablerepo=%s", repos.enable))
 	}
 	// Tack the fully qualfied package name on. This assumes any vetting of args has already been done.
 	out = append(out, fmt.Sprintf("%s-%s", name, version))

--- a/services/packages/server/packages_test.go
+++ b/services/packages/server/packages_test.go
@@ -164,7 +164,7 @@ func TestInstall(t *testing.T) {
 	// Test 2: A clean install. Validate we got expected output back.
 	// This is assuming yum based installs for testing command builder.
 	YumBin = "yum"
-	wantCmdLine := fmt.Sprintf("%s install-nevra -y --enablerepo=somerepo --disablerepo=otherrepo package-1.2.3", YumBin)
+	wantCmdLine := fmt.Sprintf("%s install-nevra -y --disablerepo=otherrepo --enablerepo=somerepo package-1.2.3", YumBin)
 
 	resp, err := client.Install(ctx, req)
 	testutil.FatalOnErr("clean install request", err, t)
@@ -385,7 +385,7 @@ func TestUpdate(t *testing.T) {
 	// This is assuming yum based installs for testing command builder.
 	YumBin = "yum"
 	wantValidateCmdLine := fmt.Sprintf("%s list installed package-0:1-1.2.3", YumBin)
-	wantCmdLine := fmt.Sprintf("%s update-to -y --enablerepo=somerepo --disablerepo=otherrepo package-0:1-4.5.6", YumBin)
+	wantCmdLine := fmt.Sprintf("%s update-to -y --disablerepo=otherrepo --enablerepo=somerepo package-0:1-4.5.6", YumBin)
 
 	resp, err := client.Update(ctx, req)
 	testutil.FatalOnErr("clean update request", err, t)


### PR DESCRIPTION
disablerepo must come first or it'll override any enablerepo you might have just set.

Generally people want --disablerepo=* --enablerepo=REPO to just
process a specific repo and reversing makes that impossible.