### PR TITLE
Add a field to RPCAuthInput indicating whether this was generated by the proxy.

### DIFF
--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -52,12 +52,20 @@ type RPCAuthInput struct {
 	// Information about the host serving the RPC.
 	Host *HostAuthInput `json:"host"`
 
-	// Whether this RPCAuthInput was generated via a proxy
-	// or directly in the RPC interceptor.
-	FromProxy bool `json:"from_proxy"`
+	// Information about the environment in which the policy evaluation is
+	// happening.
+	Environment *EnvironmentInput `json:"environment"`
 
 	// Implementation specific extensions.
 	Extensions json.RawMessage `json:"extensions"`
+}
+
+// EnvironmentInput contains information about the environment in which the policy evaluation is
+// happening.
+type EnvironmentInput struct {
+	// True if the policy evaluation is being performed by some entity other than the host
+	// (for example, policy checks performed by an authorizing proxy or other agent)
+	NonHostPolicyCheck bool `json:"non_host_policy_check"`
 }
 
 // PeerAuthInput contains policy-relevant information about an RPC peer.

--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -52,6 +52,10 @@ type RPCAuthInput struct {
 	// Information about the host serving the RPC.
 	Host *HostAuthInput `json:"host"`
 
+	// Whether this RPCAuthInput was generated via a proxy
+	// or directly in the RPC interceptor.
+	FromProxy bool `json:"from_proxy"`
+
 	// Implementation specific extensions.
 	Extensions json.RawMessage `json:"extensions"`
 }

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -279,6 +279,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				Cert:      streamPeerInfo.Cert,
 				Principal: streamPeerInfo.Principal,
 			}
+			authinput.FromProxy = true
 
 			// If authz fails, close immediately with an error
 			if err := s.authorizer.Eval(ctx, authinput); err != nil {

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -279,7 +279,9 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				Cert:      streamPeerInfo.Cert,
 				Principal: streamPeerInfo.Principal,
 			}
-			authinput.FromProxy = true
+			authinput.Environment = &rpcauth.EnvironmentInput{
+				NonHostPolicyCheck: true,
+			}
 
 			// If authz fails, close immediately with an error
 			if err := s.authorizer.Eval(ctx, authinput); err != nil {


### PR DESCRIPTION
If false we assume it's direct RPC's (via the interceptor).

This allows hooks/code/policy to make separate decisions based on the origin of the auth request.