### PR TITLE
After more consideration revert the logging on rpcauth.

### DIFF
--- a/auth/opa/rpcauth/input.go
+++ b/auth/opa/rpcauth/input.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"fmt"
 	"net"
-	"reflect"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -56,57 +54,6 @@ type RPCAuthInput struct {
 
 	// Implementation specific extensions.
 	Extensions json.RawMessage `json:"extensions"`
-}
-
-// RPCAuthInputForLogging is a mirror struct for RPCAuthInput which
-// translates the json.RawMessage fields into strings type wise.
-// This allows logging as human readable values vs [xx, yy, zz] style
-// NOTE: This must be updated when RPCAuthInput changes.
-type RPCAuthInputForLogging struct {
-	Method      string         `json:"method"`
-	Message     string         `json:"message"`
-	MessageType string         `json:"type"`
-	Metadata    metadata.MD    `json:"metadata"`
-	Peer        *PeerAuthInput `json:"peer"`
-	Host        *HostAuthInput `json:"host"`
-	Extensions  string         `json:"extensions,string"`
-}
-
-func (r RPCAuthInput) MarshalLog() interface{} {
-	// Transform for logging by forcing the types
-	// for raw JSON into string. Otherwise logr
-	// will print them as strings of bytes. If we
-	// cast to string for the whole object then
-	// we end up with string escaping.
-	return RPCAuthInputForLogging{
-		Method:      r.Method,
-		Message:     string(r.Message),
-		MessageType: r.MessageType,
-		Metadata:    r.Metadata,
-		Peer:        r.Peer,
-		Host:        r.Host,
-		Extensions:  string(r.Extensions),
-	}
-}
-
-func init() {
-	// Sanity check we didn't get the 2 structs out of sync.
-	r := reflect.TypeOf(RPCAuthInput{})
-	rl := reflect.TypeOf(RPCAuthInputForLogging{})
-
-	rFields := reflect.VisibleFields(r)
-	rlFields := reflect.VisibleFields(rl)
-	m := make(map[string]bool)
-	ml := make(map[string]bool)
-	for _, f := range rFields {
-		m[f.Name] = true
-	}
-	for _, f := range rlFields {
-		ml[f.Name] = true
-	}
-	if !reflect.DeepEqual(m, ml) {
-		panic(fmt.Sprintf("fields from RPCAuthInput (%v) do not match fields from RPCAuthInputForLogging (%v)", m, ml))
-	}
 }
 
 // PeerAuthInput contains policy-relevant information about an RPC peer.

--- a/services/fdb/server/fdbcli.go
+++ b/services/fdb/server/fdbcli.go
@@ -229,7 +229,6 @@ func (s *server) FDBCLI(req *pb.FDBCLIRequest, stream pb.CLI_FDBCLIServer) error
 		opts = append(opts, util.EnvVar(e))
 	}
 
-	fmt.Printf("Execing: %q\n", command)
 	run, err := util.RunCommand(stream.Context(), command[0], command[1:], opts...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "error running fdbcli cmd (%+v): %v", command, err)


### PR DESCRIPTION
Instead just let the logger convert the struct based on tags, etc. Default logr/funcr will print message as a byte array. But..this then allows someone to write their own logger to convert it.

Forcing it to a string ends up having side effects in logr/funcr otherwise.

Cleanup a debug log that slipped into fdbcli