### PR TITLE
Things calling exec directly not handling bad commands (bad path)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
         with:
-          go-version: '^1.18'
+          go-version-file: 'go.mod'
       - name: Install tools
         run: |
           sudo apt-get update

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
       with:
-        go-version: '^1.18'
+        go-version-file: 'go.mod'
     - name: Install tools
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
+    - uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
     - name: Install tools
@@ -20,8 +20,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
       - name: Install tools

--- a/services/ansible/client/client.go
+++ b/services/ansible/client/client.go
@@ -129,6 +129,9 @@ func (a *playbookCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 			continue
 		}
 		fmt.Fprintf(state.Out[r.Index], "Return code: %d\nStdout:%s\nStderr:%s\n", r.Resp.ReturnCode, r.Resp.Stdout, r.Resp.Stderr)
+		if r.Resp.ReturnCode != 0 {
+			retCode = subcommands.ExitFailure
+		}
 	}
 	return retCode
 }

--- a/services/ansible/server/ansible.go
+++ b/services/ansible/server/ansible.go
@@ -108,6 +108,9 @@ func (s *server) Run(ctx context.Context, req *pb.RunRequest) (*pb.RunReply, err
 	if err != nil {
 		return nil, err
 	}
+	if run.Error != nil {
+		return nil, err
+	}
 
 	return &pb.RunReply{
 		Stdout:     run.Stdout.String(),

--- a/services/ansible/server/ansible_test.go
+++ b/services/ansible/server/ansible_test.go
@@ -103,6 +103,7 @@ func TestRun(t *testing.T) {
 		returnCodeNonZero bool
 		stdout            string
 		stderr            string
+		stderrNocmp       bool
 	}{
 		{
 			name:    "A non-absolute bin path",
@@ -119,6 +120,7 @@ func TestRun(t *testing.T) {
 			bin:               "/non-existant-command",
 			path:              path,
 			returnCodeNonZero: true,
+			stderrNocmp:       true, // can't guarentee error message cross platform
 		},
 		{
 			name:              "A command that exits non-zero",
@@ -211,8 +213,14 @@ func TestRun(t *testing.T) {
 			if got, want := resp.Stdout, tc.stdout; got != want {
 				t.Fatalf("%s: Stdout doesn't match. Want %q Got %q", tc.name, want, got)
 			}
-			if got, want := resp.Stderr, tc.stderr; got != want {
-				t.Fatalf("%s: Stderr doesn't match. Want %q Got %q", tc.name, want, got)
+			if !tc.stderrNocmp {
+				if got, want := resp.Stderr, tc.stderr; got != want {
+					t.Fatalf("%s: Stderr doesn't match. Want %q Got %q", tc.name, want, got)
+				}
+			} else {
+				if resp.Stderr == "" {
+					t.Fatalf("%s: got empty stderr when we should have something", tc.name)
+				}
 			}
 		})
 	}

--- a/services/ansible/server/ansible_test.go
+++ b/services/ansible/server/ansible_test.go
@@ -103,7 +103,6 @@ func TestRun(t *testing.T) {
 		returnCodeNonZero bool
 		stdout            string
 		stderr            string
-		stderrNocmp       bool
 	}{
 		{
 			name:    "A non-absolute bin path",
@@ -116,11 +115,10 @@ func TestRun(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:              "A bad command that doesn't exec",
-			bin:               "/non-existant-command",
-			path:              path,
-			returnCodeNonZero: true,
-			stderrNocmp:       true, // can't guarentee error message cross platform
+			name:    "A bad command that doesn't exec",
+			bin:     "/non-existant-command",
+			path:    path,
+			wantErr: true,
 		},
 		{
 			name:              "A command that exits non-zero",
@@ -213,14 +211,8 @@ func TestRun(t *testing.T) {
 			if got, want := resp.Stdout, tc.stdout; got != want {
 				t.Fatalf("%s: Stdout doesn't match. Want %q Got %q", tc.name, want, got)
 			}
-			if !tc.stderrNocmp {
-				if got, want := resp.Stderr, tc.stderr; got != want {
-					t.Fatalf("%s: Stderr doesn't match. Want %q Got %q", tc.name, want, got)
-				}
-			} else {
-				if resp.Stderr == "" {
-					t.Fatalf("%s: got empty stderr when we should have something", tc.name)
-				}
+			if got, want := resp.Stderr, tc.stderr; got != want {
+				t.Fatalf("%s: Stderr doesn't match. Want %q Got %q", tc.name, want, got)
 			}
 		})
 	}

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -105,6 +105,9 @@ func (p *runCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface
 			fmt.Fprintf(state.Err[r.Index], "%s", r.Resp.Stderr)
 		}
 		fmt.Fprintf(state.Out[r.Index], "%s", r.Resp.Stdout)
+		if r.Resp.RetCode != 0 {
+			returnCode = subcommands.ExitFailure
+		}
 	}
 	return returnCode
 }

--- a/services/exec/server/exec.go
+++ b/services/exec/server/exec.go
@@ -36,6 +36,9 @@ func (s *server) Run(ctx context.Context, req *pb.ExecRequest) (res *pb.ExecResp
 		return nil, err
 	}
 
+	if run.Error != nil {
+		return nil, run.Error
+	}
 	return &pb.ExecResponse{Stderr: run.Stderr.Bytes(), Stdout: run.Stdout.Bytes(), RetCode: int32(run.ExitCode)}, nil
 }
 

--- a/services/exec/server/exec.go
+++ b/services/exec/server/exec.go
@@ -36,15 +36,7 @@ func (s *server) Run(ctx context.Context, req *pb.ExecRequest) (res *pb.ExecResp
 		return nil, err
 	}
 
-	if err := run.Error; err != nil {
-		return &pb.ExecResponse{
-			Stdout:  run.Stdout.Bytes(),
-			Stderr:  run.Stderr.Bytes(),
-			RetCode: int32(run.ExitCode),
-		}, nil
-	}
-
-	return &pb.ExecResponse{Stderr: run.Stderr.Bytes(), Stdout: run.Stdout.Bytes(), RetCode: 0}, nil
+	return &pb.ExecResponse{Stderr: run.Stderr.Bytes(), Stdout: run.Stdout.Bytes(), RetCode: int32(run.ExitCode)}, nil
 }
 
 // Register is called to expose this handler to the gRPC server

--- a/services/exec/server/exec_test.go
+++ b/services/exec/server/exec_test.go
@@ -84,9 +84,9 @@ func TestExec(t *testing.T) {
 			returnCodeNonZero: true,
 		},
 		{
-			name:              "Non-existant program",
-			bin:               "/something/non-existant",
-			returnCodeNonZero: true,
+			name:    "Non-existant program",
+			bin:     "/something/non-existant",
+			wantErr: true,
 		},
 		{
 			name:    "non-absolute path",

--- a/services/fdb/server/fdbcli.go
+++ b/services/fdb/server/fdbcli.go
@@ -236,6 +236,9 @@ func (s *server) FDBCLI(req *pb.FDBCLIRequest, stream pb.CLI_FDBCLIServer) error
 	if run.Error != nil {
 		return status.Errorf(codes.Internal, "can't exec fdbcli: %v - %s", run.Error, run.Stderr)
 	}
+	if run.ExitCode != 0 {
+		return status.Errorf(codes.Internal, "fdbcli returned non-zero: %d - %v - %s", run.ExitCode, run.Error, run.Stderr)
+	}
 
 	// Make sure we always remove logs even if errors happen below.
 	defer func() {

--- a/services/packages/server/packages.go
+++ b/services/packages/server/packages.go
@@ -181,7 +181,7 @@ func (s *server) Install(ctx context.Context, req *pb.InstallRequest) (*pb.Insta
 		return nil, err
 	}
 
-	if err := run.Error; err != nil {
+	if err := run.Error; run.ExitCode != 0 || err != nil {
 		return nil, status.Errorf(codes.Internal, "error from running - %v\nstdout:\n%s\nstderr:\n%s", err, util.TrimString(run.Stdout.String()), util.TrimString(run.Stderr.String()))
 	}
 
@@ -230,7 +230,7 @@ func (s *server) Update(ctx context.Context, req *pb.UpdateRequest) (*pb.UpdateR
 	if err != nil {
 		return nil, err
 	}
-	if err := run.Error; err != nil {
+	if err := run.Error; run.ExitCode != 0 || err != nil {
 		return nil, status.Errorf(codes.Internal, "package %s at version %s doesn't appear to be installed.\nStderr:\n%s", req.Name, req.OldVersion, util.TrimString(run.Stderr.String()))
 	}
 
@@ -239,7 +239,7 @@ func (s *server) Update(ctx context.Context, req *pb.UpdateRequest) (*pb.UpdateR
 	if err != nil {
 		return nil, err
 	}
-	if err := run.Error; err != nil {
+	if err := run.Error; run.ExitCode != 0 || err != nil {
 		return nil, status.Errorf(codes.Internal, "error from running %q: %v", updateCommand, err)
 	}
 
@@ -335,7 +335,7 @@ func (s *server) ListInstalled(ctx context.Context, req *pb.ListInstalledRequest
 	if err != nil {
 		return nil, err
 	}
-	if err := run.Error; err != nil {
+	if err := run.Error; run.ExitCode != 0 || err != nil {
 		return nil, status.Errorf(codes.Internal, "error from running %q: %v", command, err)
 	}
 
@@ -439,7 +439,7 @@ func (s *server) RepoList(ctx context.Context, req *pb.RepoListRequest) (*pb.Rep
 	if err != nil {
 		return nil, err
 	}
-	if err := run.Error; err != nil {
+	if err := run.Error; run.ExitCode != 0 || err != nil {
 		return nil, status.Errorf(codes.Internal, "error from running %q: %v\nstdout:\n%s\nstderr:\n%s", command, err, util.TrimString(run.Stdout.String()), util.TrimString(run.Stderr.String()))
 	}
 

--- a/services/process/server/process.go
+++ b/services/process/server/process.go
@@ -119,8 +119,8 @@ func (s *server) List(ctx context.Context, req *pb.ListRequest) (*pb.ListReply, 
 		return nil, err
 	}
 
-	if err := run.Error; err != nil {
-		return nil, status.Errorf(codes.Internal, "command exited with error: %v\n%s", err, util.TrimString(run.Stderr.String()))
+	if err := run.Error; run.ExitCode != 0 || err != nil {
+		return nil, status.Errorf(codes.Internal, "command exited with error/non-zero exit: %v (%d)\n%s", err, run.ExitCode, util.TrimString(run.Stderr.String()))
 	}
 
 	entries, err := parser(run.Stdout)
@@ -177,8 +177,8 @@ func (s *server) GetStacks(ctx context.Context, req *pb.GetStacksRequest) (*pb.G
 		return nil, err
 	}
 
-	if err := run.Error; err != nil {
-		return nil, status.Errorf(codes.Internal, "command exited with error: %v\n%s", err, util.TrimString(run.Stderr.String()))
+	if err := run.Error; run.ExitCode != 0 || err != nil {
+		return nil, status.Errorf(codes.Internal, "command exited with error/non-zero exit: %v (%d)\n%s", err, run.ExitCode, util.TrimString(run.Stderr.String()))
 	}
 
 	scanner := bufio.NewScanner(run.Stdout)
@@ -248,8 +248,8 @@ func (s *server) GetJavaStacks(ctx context.Context, req *pb.GetJavaStacksRequest
 		return nil, err
 	}
 
-	if err := run.Error; err != nil {
-		return nil, status.Errorf(codes.Internal, "command exited with error: %v\n%s", err, util.TrimString(run.Stderr.String()))
+	if err := run.Error; run.ExitCode != 0 || err != nil {
+		return nil, status.Errorf(codes.Internal, "command exited with error/non-zero exit: %v (%d)\n%s", err, run.ExitCode, util.TrimString(run.Stderr.String()))
 	}
 
 	scanner := bufio.NewScanner(run.Stdout)
@@ -429,8 +429,8 @@ func (s *server) GetMemoryDump(req *pb.GetMemoryDumpRequest, stream pb.Process_G
 		return err
 	}
 
-	if err := run.Error; err != nil {
-		return status.Errorf(codes.Internal, "command exited with error: %v\n%s", err, util.TrimString(run.Stderr.String()))
+	if err := run.Error; run.ExitCode != 0 || err != nil {
+		return status.Errorf(codes.Internal, "command exited with error/non-zero exit: %v (%d)\n%s", err, run.ExitCode, util.TrimString(run.Stderr.String()))
 	}
 
 	f, err := os.Open(file)

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -251,12 +251,10 @@ func RunCommand(ctx context.Context, bin string, args []string, opts ...Option) 
 	run.Error = cmd.Run()
 	run.ExitCode = cmd.ProcessState.ExitCode()
 	// If this was an error it could be two different things. Just exiting non-zero results in an exec.ExitError
-	// so we can assume the command wrote anything relevant. If instead it's an error from exec itself it'll
-	// be a different type and we should emit that to the stderr output.
-	// i.e. simply getting an error from exec isn't an error from RunCommand itself so we need to wrap this.
+	// and we can suppress that as exit code is enough. Otherwise we leave run.Error for callers to use.
 	if run.Error != nil {
-		if _, ok := run.Error.(*exec.ExitError); !ok {
-			run.Stderr.buf.WriteString(fmt.Sprintf("%v\n", run.Error))
+		if _, ok := run.Error.(*exec.ExitError); ok {
+			run.Error = nil
 		}
 	}
 	if options.failOnStderr && len(run.Stderr.String()) != 0 {


### PR DESCRIPTION
If we exec something that returns non-zero it can happen for 2 reasons:

1. Command simply ran and exited non-zero. That works as expected mostly except the client code didn't error out for any target exiting this way. So fix client code to exit non-zero if any target fails.

2. Command couldn't run (i.e. exec error). That's returned from exec.RunCommand as an error. But we may have nothing in stderr. In this case we should copy the error to stderr since errors here are for commands not being setup correctly. Exit code was already right but otherwise we ate the error string and couldn't see why it failed. 

Adjust all the tests so they account for this too and add an integration test.

Ansible had same issues as exec due to this.