### PR TITLE
If Ansible returns an error from RunCommand handle it correctly.

### DIFF
--- a/services/ansible/server/ansible.go
+++ b/services/ansible/server/ansible.go
@@ -109,8 +109,8 @@ func (s *server) Run(ctx context.Context, req *pb.RunRequest) (*pb.RunReply, err
 	if err != nil {
 		return nil, err
 	}
-	if run.Error != nil {
-		return nil, err
+	if err := run.Error; err != nil {
+		return nil, status.Errorf(codes.Internal, "command exited with error: %v (%d)\n%s", err, run.ExitCode, util.TrimString(run.Stderr.String()))
 	}
 
 	return &pb.RunReply{


### PR DESCRIPTION
Before we checked but then returned err which we know is nil because it got through the check above.

This means we passed nil, nil back to grpc which doesn't like it:

2022/10/11 00:18:29 ERROR: [core] [Server #4] grpc: server failed to encode response: rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil

Instead capture the error and put it inside a proper status.Error