### PR TITLE
Add a way to do command line completion in sanssh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ There is a reference implementation of a SansShell CLI Client in
 as a way to implement "convenience" commands which chain together a series of
 actions.
 
+It also demonstrates how to set up command line completion. To use this, set
+the appropriate line in your shell configuration.
+
+```shell
+# In .bashrc
+complete -C /path/to/sanssh sanssh
+# Or in .zshrc
+autoload -Uz compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+complete -C /path/to/sanssh sanssh
+```
+
 # Extending SansShell
 SansShell is built on a principle of "Don't pay for what you don't use".  This
 is advantageous in both minimizing the resources of SansShell server (binary

--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ the appropriate line in your shell configuration.
 
 ```shell
 # In .bashrc
-complete -C /path/to/sanssh sanssh
+complete -C /path/to/sanssh -o dirnames sanssh
 # Or in .zshrc
 autoload -Uz compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
-complete -C /path/to/sanssh sanssh
+complete -C /path/to/sanssh -o dirnames sanssh
 ```
 
 # Extending SansShell

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,12 @@ import (
 	"github.com/google/subcommands"
 )
 
+// HasSubpackage should be implemented by users of SetupSubpackage to
+// help with introspecting subpackages of subcommands.
+type HasSubpackage interface {
+	GetSubpackage(f *flag.FlagSet) *subcommands.Commander
+}
+
 // SetupSubpackage is a helper to create a Commander to hold the actual
 // commands run inside of a top-level command. The returned Commander should
 // then have the relevant sub-commands registered within it.
@@ -68,4 +74,14 @@ func GenerateSynopsis(c *subcommands.Commander, leading int) string {
 // sub-commands contained within it.
 func GenerateUsage(name string, synopsis string) string {
 	return fmt.Sprintf("%s has several subcommands. Pick one to perform the action you wish:\n%s", name, synopsis)
+}
+
+// PredictArgs can optionally be implemented to help with command-line completion. It will typically be implemented
+// on a type that already implements subcommands.Command.
+type PredictArgs interface {
+	// PredictArgs returns prediction options for a given prefix. The prefix is
+	// the subcommand arguments that have been typed so far (possibly nothing)
+	// and can be used as a hint for what to return. The returned values will be
+	// automatically filtered by the prefix when needed.
+	PredictArgs(prefix string) []string
 }

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -135,6 +135,11 @@ func Run(ctx context.Context, rs RunState) {
 			}
 		}
 	}
+	if len(flag.Args()) <= 1 {
+		// If there's no flags or only one flag, whoever's running this is probably still learning how
+		// to invoke the tool and not trying to run the command.
+		os.Exit(int(subcommands.Execute(ctx, &util.ExecuteState{})))
+	}
 
 	// Bunch of flag sanity checking
 	if len(rs.Targets) == 0 && rs.Proxy == "" {

--- a/cmd/sanssh/client/completion.go
+++ b/cmd/sanssh/client/completion.go
@@ -94,7 +94,7 @@ func (c *cmdCompleter) GetFlag(flag, prefix string) []string {
 	if predictor := c.flagPredictions[flag]; predictor != nil {
 		return predictor(prefix)
 	}
-	return []string{prefix}
+	return nil
 }
 func (c *cmdCompleter) GetArgs(prefix string) []string {
 	return nil
@@ -139,7 +139,7 @@ func (c *subCompleter) ListFlags() []string {
 }
 
 func (c *subCompleter) GetFlag(flag, prefix string) []string {
-	return []string{prefix}
+	return nil
 }
 
 func (c *subCompleter) IsBoolFlag(fl string) bool {

--- a/cmd/sanssh/client/completion.go
+++ b/cmd/sanssh/client/completion.go
@@ -1,0 +1,227 @@
+package client
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Snowflake-Labs/sansshell/client"
+	"github.com/google/subcommands"
+)
+
+// This file gives an easy way for clients to implement command line completion.
+// To test manually, try running a command that sets the appropriate
+// environmental variable.
+// COMP_LINE="sanssh --" ./sanssh
+
+type isBoolFlag interface {
+	IsBoolFlag() bool
+}
+
+func flagIsBool(fl string, visitor func(fn func(*flag.Flag))) bool {
+	var isBool bool
+	visitor(func(f *flag.Flag) {
+		if f.Name == fl {
+			b, ok := f.Value.(isBoolFlag)
+			isBool = isBool || ok && b.IsBoolFlag()
+		}
+	})
+	return isBool
+}
+
+type completer interface {
+	// ListCommandsAndEssentialFlags lists subcommands and important flags of the
+	// current command. Flags should be prefixed with dashes.
+	ListCommandsAndEssentialFlags() []string
+	// GetCommandCompleter returns a completer for the provided subcommand.
+	// The provided subcommand may not exist.
+	GetCommandCompleter(cmd string) completer
+	// ListFlags lists flags for the current completion level. Flags should be prefixed
+	// with dashes.
+	ListFlags() []string
+	// GetFlag gives possible values for the provided flag.
+	// Results are automatically filtered as needed.
+	GetFlag(flag, prefix string) []string
+	// IsBoolFlag is true if the flag may be set without any value
+	IsBoolFlag(flag string) bool
+	// GetArgs is called when ListCommands is empty. It's given everything
+	// typed so far since the last subcommand.
+	// Results are automatically filtered as needed.
+	GetArgs(prefix string) []string
+}
+
+// cmdCompleter and subCompleter mutually recurse with each other to support
+// subcommands of subcommands.
+type cmdCompleter struct {
+	commander       *subcommands.Commander
+	flagPredictions map[string]Predictor
+}
+
+func (c *cmdCompleter) ListCommandsAndEssentialFlags() []string {
+	var subs []string
+	c.commander.VisitCommands(func(_ *subcommands.CommandGroup, cmd subcommands.Command) {
+		// Remove some commands that seem unneccesary for command line completion.
+		if cmd.Name() != c.commander.CommandsCommand().Name() && cmd.Name() != c.commander.FlagsCommand().Name() {
+			subs = append(subs, cmd.Name())
+		}
+	})
+	c.commander.VisitAllImportant(func(f *flag.Flag) {
+		subs = append(subs, "--"+f.Name)
+	})
+	return subs
+}
+func (c *cmdCompleter) GetCommandCompleter(cmd string) completer {
+	var found subcommands.Command
+	c.commander.VisitCommands(func(_ *subcommands.CommandGroup, c subcommands.Command) {
+		if c.Name() == cmd {
+			found = c
+		}
+	})
+	if found == nil {
+		return nil
+	}
+	return &subCompleter{found}
+}
+func (c *cmdCompleter) ListFlags() []string {
+	var flags []string
+	c.commander.VisitAll(func(f *flag.Flag) {
+		flags = append(flags, "--"+f.Name)
+	})
+	return flags
+}
+func (c *cmdCompleter) GetFlag(flag, prefix string) []string {
+	if predictor := c.flagPredictions[flag]; predictor != nil {
+		return predictor(prefix)
+	}
+	return []string{prefix}
+}
+func (c *cmdCompleter) GetArgs(prefix string) []string {
+	return nil
+}
+
+func (c *cmdCompleter) IsBoolFlag(flag string) bool {
+	return flagIsBool(flag, c.commander.VisitAll)
+}
+
+func fromSubpackage(s client.HasSubpackage) completer {
+	return &cmdCompleter{commander: s.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError))}
+}
+
+type subCompleter struct {
+	command subcommands.Command
+}
+
+func (c *subCompleter) ListCommandsAndEssentialFlags() []string {
+	s, ok := c.command.(client.HasSubpackage)
+	if !ok {
+		return nil
+	}
+	return fromSubpackage(s).ListCommandsAndEssentialFlags()
+}
+func (c *subCompleter) GetCommandCompleter(cmd string) completer {
+	s, ok := c.command.(client.HasSubpackage)
+	if !ok {
+		return nil
+	}
+	return fromSubpackage(s).GetCommandCompleter(cmd)
+}
+func (c *subCompleter) ListFlags() []string {
+	s := flag.NewFlagSet(c.command.Name(), flag.ContinueOnError)
+	c.command.SetFlags(s)
+	var flags []string
+	s.VisitAll(func(f *flag.Flag) {
+		flags = append(flags, "--"+f.Name)
+	})
+	return flags
+}
+
+func (c *subCompleter) GetFlag(flag, prefix string) []string {
+	return []string{prefix}
+}
+
+func (c *subCompleter) IsBoolFlag(fl string) bool {
+	s := flag.NewFlagSet(c.command.Name(), flag.ContinueOnError)
+	c.command.SetFlags(s)
+	return flagIsBool(fl, s.VisitAll)
+}
+
+func (c *subCompleter) GetArgs(prefix string) []string {
+	if args, ok := c.command.(client.PredictArgs); ok {
+		return args.PredictArgs(prefix)
+	}
+	return nil
+}
+
+func filterToPrefix(args []string, prefix string) []string {
+	var s []string
+	for _, a := range args {
+		if strings.HasPrefix(a, prefix) {
+			s = append(s, a)
+		}
+	}
+	return s
+}
+
+var validBools = map[string]bool{
+	"1": true, "0": true, "t": true, "f": true, "T": true, "F": true, "true": true, "false": true, "TRUE": true, "FALSE": true, "True": true, "False": true,
+}
+
+func predict(c completer, args []string) []string {
+	// Flags require special handling
+	if strings.HasPrefix(args[0], "-") {
+		flagName := strings.TrimLeft(args[0], "-")
+		switch len(args) {
+		case 1:
+			return filterToPrefix(c.ListFlags(), args[0])
+		case 2:
+			if c.IsBoolFlag(flagName) {
+				return predict(c, args[1:])
+			}
+			return c.GetFlag(flagName, args[1])
+		default:
+			if strings.Contains(flagName, "=") || (c.IsBoolFlag(flagName) && !validBools[args[1]]) {
+				return predict(c, args[1:])
+			}
+			return predict(c, args[2:])
+		}
+	}
+	if len(args) > 1 {
+		next := c.GetCommandCompleter(args[0])
+		if next == nil {
+			prefix := strings.Join(args, " ")
+			return filterToPrefix(c.GetArgs(prefix), prefix)
+		}
+		return predict(next, args[1:])
+	}
+	return filterToPrefix(c.ListCommandsAndEssentialFlags(), args[0])
+}
+
+// Predictor can provide suggested values based on a provided prefix.
+type Predictor func(prefix string) []string
+
+// AddCommandLineCompletion adds command line completion for shells. It should be called after
+// registering all subcommands and before calling flag.Parse().
+//
+// topLevelFlagPredictions gives optional finer-grained control over predictions on the top-level
+// flags.
+func AddCommandLineCompletion(topLevelFlagPredictions map[string]Predictor) {
+	// If COMP_LINE is present, we're running as command completion.
+	compLine, ok := os.LookupEnv("COMP_LINE")
+	if !ok {
+		return
+	}
+
+	c := &cmdCompleter{commander: subcommands.DefaultCommander, flagPredictions: topLevelFlagPredictions}
+	args := strings.Fields(compLine)
+	args = args[1:] // Skip the self-arg
+	if compLine[len(compLine)-1] == ' ' {
+		args = append(args, "") // Append a blank arg at the end when we're starting a new word
+	}
+
+	for _, prediction := range predict(c, args) {
+		fmt.Println(prediction)
+	}
+
+	os.Exit(0)
+}

--- a/cmd/sanssh/client/completion_test.go
+++ b/cmd/sanssh/client/completion_test.go
@@ -1,0 +1,166 @@
+package client
+
+import (
+	"context"
+	"flag"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/Snowflake-Labs/sansshell/client"
+	"github.com/google/subcommands"
+)
+
+type subCmd struct{ name string }
+
+func (s *subCmd) Name() string           { return s.name }
+func (*subCmd) Synopsis() string         { return "" }
+func (*subCmd) Usage() string            { return "" }
+func (*subCmd) SetFlags(f *flag.FlagSet) { f.String("foo", "", "") }
+func (s *subCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	return s.GetSubpackage(f).Execute(ctx, args...)
+}
+func (s *subCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
+	return client.SetupSubpackage(s.name, f)
+}
+
+type emptyCmd struct{ name string }
+
+func (*emptyCmd) Name() string             { return "empty" }
+func (*emptyCmd) Synopsis() string         { return "" }
+func (*emptyCmd) Usage() string            { return "" }
+func (*emptyCmd) SetFlags(f *flag.FlagSet) { f.Bool("ebool", false, "") }
+func (*emptyCmd) Execute(context.Context, *flag.FlagSet, ...interface{}) subcommands.ExitStatus {
+	return subcommands.ExitSuccess
+}
+func (*emptyCmd) PredictArgs(string) []string { return []string{"emptyargv"} }
+
+func TestPredict(t *testing.T) {
+	topLevelFlags := flag.NewFlagSet("", flag.ContinueOnError)
+	topLevelFlags.String("important", "", "")
+	topLevelFlags.String("unimportant", "", "")
+	topLevelFlags.Bool("boolean", false, "")
+	cmdr := subcommands.NewCommander(topLevelFlags, "sanssh")
+	cmdr.Register(&subCmd{name: "sub"}, "")
+	cmdr.Register(&emptyCmd{}, "")
+	cmdr.ImportantFlag("important")
+	c := &cmdCompleter{commander: cmdr, flagPredictions: map[string]Predictor{
+		"unimportant": func(string) []string { return []string{"ab", "cd"} },
+	}}
+
+	for _, tc := range []struct {
+		desc string
+		line string
+		want []string
+	}{
+		{
+			desc: "empty line",
+			line: "",
+			want: nil,
+		},
+		{
+			desc: "command start",
+			line: "sanssh ",
+			want: []string{"--important", "empty", "sub"},
+		},
+		{
+			desc: "choosing flags",
+			line: "sanssh -",
+			want: []string{"--boolean", "--important", "--unimportant"},
+		},
+		{
+			desc: "choosing flag values",
+			line: "sanssh --unimportant ",
+			want: []string{"ab", "cd"},
+		},
+		{
+			desc: "choosing flag values, no prediction",
+			line: "sanssh --important s",
+			want: []string{"s"},
+		},
+		{
+			desc: "choosing flag values, equals",
+			line: "sanssh --unimportant=",
+			want: []string{"--unimportant=ab", "--unimportant=cd"},
+		},
+		{
+			desc: "choosing flag values, equals and partial",
+			line: "sanssh --unimportant=a",
+			want: []string{"--unimportant=ab"},
+		},
+		{
+			desc: "completing subcommand",
+			line: "sanssh s",
+			want: []string{"sub"},
+		},
+		{
+			desc: "completing subsubcommand",
+			line: "sanssh sub ",
+			want: []string{"help"},
+		},
+		{
+			desc: "subcommand flag",
+			line: "sanssh sub --fo",
+			want: []string{"--foo"},
+		},
+		{
+			desc: "subcommand flag val",
+			line: "sanssh sub --foo bar",
+			want: []string{"bar"},
+		},
+		{
+			desc: "finished subsubcommand",
+			line: "sanssh sub help ",
+			want: nil,
+		},
+		{
+			desc: "trying wrong subsubcommand",
+			line: "sanssh sub help args ",
+			want: nil,
+		},
+		{
+			desc: "flag and subcommand",
+			line: "sanssh --important foo s",
+			want: []string{"sub"},
+		},
+		{
+			desc: "bool flag and subcommand",
+			line: "sanssh -boolean --important foo s",
+			want: []string{"sub"},
+		},
+		{
+			desc: "fake subcommand",
+			line: "sanssh notfound ",
+			want: nil,
+		},
+		{
+			desc: "empty subcommand",
+			line: "sanssh empty ",
+			want: []string{"--ebool", "emptyargv"},
+		},
+		{
+			desc: "empty args",
+			line: "sanssh empty e",
+			want: []string{"emptyargv"},
+		},
+		{
+			desc: "empty args with flag",
+			line: "sanssh empty -ebool e",
+			want: []string{"emptyargv"},
+		},
+		{
+			desc: "empty args with not-subcommand",
+			line: "sanssh empty args ",
+			want: nil,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := predictLine(c, tc.line)
+			sort.Strings(got)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+
+		})
+	}
+}

--- a/cmd/sanssh/client/completion_test.go
+++ b/cmd/sanssh/client/completion_test.go
@@ -24,7 +24,7 @@ func (s *subCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	return client.SetupSubpackage(s.name, f)
 }
 
-type emptyCmd struct{ name string }
+type emptyCmd struct{}
 
 func (*emptyCmd) Name() string             { return "empty" }
 func (*emptyCmd) Synopsis() string         { return "" }
@@ -76,7 +76,7 @@ func TestPredict(t *testing.T) {
 		{
 			desc: "choosing flag values, no prediction",
 			line: "sanssh --important s",
-			want: []string{"s"},
+			want: nil,
 		},
 		{
 			desc: "choosing flag values, equals",
@@ -106,7 +106,7 @@ func TestPredict(t *testing.T) {
 		{
 			desc: "subcommand flag val",
 			line: "sanssh sub --foo bar",
-			want: []string{"bar"},
+			want: nil,
 		},
 		{
 			desc: "finished subsubcommand",

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -118,6 +118,10 @@ func main() {
 	// as that means just talk to --targets[0] instead.
 	// If the flag itself was set that will override.
 	*proxyAddr = os.Getenv(proxyEnv)
+
+	client.AddCommandLineCompletion(map[string]client.Predictor{
+		"targets": func(string) []string { return []string{"localhost"} },
+	})
 	flag.Parse()
 
 	// If we're given a --targets-file read it in and stuff into targetsFlag

--- a/services/ansible/client/client.go
+++ b/services/ansible/client/client.go
@@ -36,7 +36,7 @@ func init() {
 	subcommands.Register(&ansibleCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*ansibleCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&playbookCmd{}, "")
 	return c
@@ -46,7 +46,7 @@ type ansibleCmd struct{}
 
 func (*ansibleCmd) Name() string { return subPackage }
 func (p *ansibleCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *ansibleCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -54,7 +54,7 @@ func (p *ansibleCmd) Usage() string {
 func (*ansibleCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *ansibleCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/dns/client/client.go
+++ b/services/dns/client/client.go
@@ -37,7 +37,7 @@ func init() {
 	subcommands.Register(&dnsCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*dnsCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&lookupCmd{}, "")
 	return c
@@ -47,7 +47,7 @@ type dnsCmd struct{}
 
 func (*dnsCmd) Name() string { return subPackage }
 func (p *dnsCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *dnsCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -55,7 +55,7 @@ func (p *dnsCmd) Usage() string {
 func (*dnsCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *dnsCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -36,7 +36,7 @@ func init() {
 	subcommands.Register(&execCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*execCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&runCmd{}, "")
 	return c
@@ -46,7 +46,7 @@ type execCmd struct{}
 
 func (*execCmd) Name() string { return subPackage }
 func (p *execCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *execCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -54,7 +54,7 @@ func (p *execCmd) Usage() string {
 func (*execCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *execCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/healthcheck/client/client.go
+++ b/services/healthcheck/client/client.go
@@ -36,7 +36,7 @@ func init() {
 	subcommands.Register(&healthcheckCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*healthcheckCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&validateCmd{}, "")
 	return c
@@ -46,7 +46,7 @@ type healthcheckCmd struct{}
 
 func (*healthcheckCmd) Name() string { return subPackage }
 func (p *healthcheckCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *healthcheckCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -54,7 +54,7 @@ func (p *healthcheckCmd) Usage() string {
 func (*healthcheckCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *healthcheckCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -41,7 +41,7 @@ func init() {
 	subcommands.Register(&fileCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*fileCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&chgrpCmd{}, "")
 	c.Register(&chmodCmd{}, "")
@@ -63,7 +63,7 @@ type fileCmd struct{}
 
 func (*fileCmd) Name() string { return subPackage }
 func (p *fileCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *fileCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -71,7 +71,7 @@ func (p *fileCmd) Usage() string {
 func (*fileCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *fileCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/packages/client/client.go
+++ b/services/packages/client/client.go
@@ -38,7 +38,7 @@ func init() {
 	subcommands.Register(&packagesCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*packagesCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&installCmd{}, "")
 	c.Register(&listCmd{}, "")
@@ -52,7 +52,7 @@ type packagesCmd struct{}
 
 func (*packagesCmd) Name() string { return subPackage }
 func (p *packagesCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *packagesCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -60,7 +60,7 @@ func (p *packagesCmd) Usage() string {
 func (*packagesCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *packagesCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/process/client/client.go
+++ b/services/process/client/client.go
@@ -39,7 +39,7 @@ func init() {
 	subcommands.Register(&processCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*processCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&dumpCmd{}, "")
 	c.Register(&jstackCmd{}, "")
@@ -53,7 +53,7 @@ type processCmd struct{}
 
 func (*processCmd) Name() string { return subPackage }
 func (p *processCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *processCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -61,7 +61,7 @@ func (p *processCmd) Usage() string {
 func (*processCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *processCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/sansshell/client/client.go
+++ b/services/sansshell/client/client.go
@@ -37,7 +37,7 @@ func init() {
 	subcommands.Register(&sansshellCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*sansshellCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	c.Register(&setVerbosityCmd{}, "")
 	c.Register(&getVerbosityCmd{}, "")
@@ -53,7 +53,7 @@ type sansshellCmd struct{}
 
 func (*sansshellCmd) Name() string { return subPackage }
 func (p *sansshellCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *sansshellCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -61,7 +61,7 @@ func (p *sansshellCmd) Usage() string {
 func (*sansshellCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *sansshellCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 

--- a/services/service/client/client.go
+++ b/services/service/client/client.go
@@ -38,7 +38,7 @@ func init() {
 	subcommands.Register(&serviceCmd{}, subPackage)
 }
 
-func setup(f *flag.FlagSet) *subcommands.Commander {
+func (*serviceCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
 	c := client.SetupSubpackage(subPackage, f)
 	initSystemTypes()
 	c.Register(&listCmd{}, "")
@@ -55,7 +55,7 @@ type serviceCmd struct{}
 
 func (*serviceCmd) Name() string { return subPackage }
 func (p *serviceCmd) Synopsis() string {
-	return client.GenerateSynopsis(setup(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
 }
 func (p *serviceCmd) Usage() string {
 	return client.GenerateUsage(subPackage, p.Synopsis())
@@ -63,7 +63,7 @@ func (p *serviceCmd) Usage() string {
 func (*serviceCmd) SetFlags(f *flag.FlagSet) {}
 
 func (p *serviceCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
-	c := setup(f)
+	c := p.GetSubpackage(f)
 	return c.Execute(ctx, args...)
 }
 


### PR DESCRIPTION
See steps in the readme for how to enable this. It relies on invoking sanssh for suggestions. Downstream clients can use `client.AddCommandLineCompletion` to take advantage of this.

This completion automatically registers subcommand packages and their flags. To register subcommands of subcommands, the parent subcommand needs to implement HasSubpackage. I've updated all the services to implement that interface.

There's also a PredictArgs interface that can be used to predict command line arguments of subcommands. I've experimented with adding this to some of the fdb subcommands.

Finally, I've tweaked the default fail-early behavior so that there's help text from running a command like `sanssh` or `sanssh exec` insted of a cryptic "Must set a target or a proxy" error.