### PR TITLE
Add README badges and update CI to run continuously.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,7 +1,14 @@
 ---
-name: PR
+name: Build and Test
 on:
-  - pull_request
+  push:
+    braches:
+      - main
+    tags:
+      - v*
+  pull_request:
+  schedule:
+    - cron:  '7 3 * * *'
 jobs:
   pre-commit:
     name: Pre commit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # SansShell
+
+[![Build Status](https://github.com/Snowflake-Labs/sansshell/workflows/Build%20and%20Test/badge.svg?branch=main)](https://github.com/Snowflake-Labs/sansshell/actions?query=workflow%3A%22Build+and+Test%229)
+[![License](https://img.shields.io/:license-Apache%202-brightgreen.svg)](https://github.com/Snowflake-Labs/sansshell/blob/main/LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Snowflake-Labs/sansshell.svg)](https://pkg.go.dev/github.com/Snowflake-Labs/sansshell)
+[![Report Card](https://goreportcard.com/badge/github.com/Snowflake-Labs/sansshell)](https://goreportcard.com/report/github.com/Snowflake-Labs/sansshell)
+
 A non-interactive daemon for host management
 
 ```mermaid


### PR DESCRIPTION
This makes the README slightly friendlier. Badges are somewhat copied from https://github.com/snowflakedb/gosnowflake.

The build status won't be valid until after submission because it'll only start having results post-submission. I've now made builds happen daily and on every update to main in addition to on PRs.