### PR TITLE
Allow loading roots of trust from a directory.

### DIFF
--- a/auth/mtls/common.go
+++ b/auth/mtls/common.go
@@ -20,21 +20,48 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 // LoadRootOfTrust will load an CA root of trust(s) from the given
 // file and return a CertPool to use in validating certificates.
 // All CA's to validate against must be presented together in the PEM
 // file.
-func LoadRootOfTrust(filename string) (*x509.CertPool, error) {
-	// Read in the root of trust for client identities
-	ca, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("could not read CA from %q: %w", filename, err)
-	}
+// If the file is a directory, LoadRootOfTrust will load all files
+// in that directory.
+func LoadRootOfTrust(path string) (*x509.CertPool, error) {
 	capool := x509.NewCertPool()
-	if !capool.AppendCertsFromPEM(ca) {
-		return nil, fmt.Errorf("could not add CA cert to pool: %w", err)
+
+	loadRoot := func(filename string) error {
+		ca, err := os.ReadFile(filename)
+		if err != nil {
+			return fmt.Errorf("could not read %q: %w", filename, err)
+		}
+		if !capool.AppendCertsFromPEM(ca) {
+			return fmt.Errorf("could not add CA cert from %q to pool: %w", filename, err)
+		}
+		return nil
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not stat CA cert path %q: %w", path, err)
+	}
+	if fi.IsDir() {
+		files, err := os.ReadDir(path)
+		if err != nil {
+			return nil, fmt.Errorf("could not read  CA cert directory %q: %w", path, err)
+		}
+		for _, f := range files {
+			if err := loadRoot(filepath.Join(path, f.Name())); err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		err := loadRoot(path)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return capool, nil
 }


### PR DESCRIPTION
Snowflake has an internal use case where we have multiple root .pem files in a single directory. We currently concatenate together all the files for sanshell, but avoiding the concatenation makes the system slightly simpler.

We'd previously returned an error when asking for a directory, so this change makes us slightly more permissive.