### PR TITLE
Add an option for an extremely minimal web debug server

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -64,7 +64,7 @@ var (
 	clientPolicyFlag = flag.String("client-policy", "", "OPA policy for outbound client actions (i.e. connecting to sansshell servers). If empty no policy is applied.")
 	clientPolicyFile = flag.String("client-policy-file", "", "Path to a file with a client OPA.  If empty uses --client-policy")
 	hostport         = flag.String("hostport", "localhost:50043", "Where to listen for connections.")
-	debugport        = flag.String("debgport", "localhost:50045", "A separate port for http debug pages.")
+	debugport        = flag.String("debugport", "localhost:50045", "A separate port for http debug pages. Set to an empty string to disable.")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS creds (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	verbosity        = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate         = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -64,6 +64,7 @@ var (
 	clientPolicyFlag = flag.String("client-policy", "", "OPA policy for outbound client actions (i.e. connecting to sansshell servers). If empty no policy is applied.")
 	clientPolicyFile = flag.String("client-policy-file", "", "Path to a file with a client OPA.  If empty uses --client-policy")
 	hostport         = flag.String("hostport", "localhost:50043", "Where to listen for connections.")
+	debugport        = flag.String("debgport", "localhost:50045", "A separate port for http debug pages.")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS creds (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	verbosity        = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate         = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")
@@ -119,5 +120,6 @@ func main() {
 		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),
 		server.WithRawServerOption(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
 		server.WithRawServerOption(srv.Register),
+		server.WithDebugPort(*debugport),
 	)
 }

--- a/cmd/proxy-server/server/server.go
+++ b/cmd/proxy-server/server/server.go
@@ -245,7 +245,7 @@ func Run(ctx context.Context, opts ...Option) {
 	}
 
 	// If there's a debug port, we want to start it early
-	if rs.debughandler != nil {
+	if rs.debughandler != nil && rs.debugport != "" {
 		go func() {
 			rs.logger.Error(http.ListenAndServe(rs.debugport, rs.debughandler), "Debug handler unexpectedly exited")
 		}()

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -74,6 +74,7 @@ var (
 	policyFlag    = flag.String("policy", defaultPolicy, "Local OPA policy governing access.  If empty, use builtin policy.")
 	policyFile    = flag.String("policy-file", "", "Path to a file with an OPA policy.  If empty, uses --policy.")
 	hostport      = flag.String("hostport", "localhost:50042", "Where to listen for connections.")
+	debugport     = flag.String("debugport", "localhost:50044", "A separate port for http debug pages.")
 	credSource    = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	verbosity     = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate      = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")
@@ -143,5 +144,6 @@ func main() {
 		server.WithJustification(*justification),
 		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),
 		server.WithRawServerOption(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),
+		server.WithDebugPort(*debugport),
 	)
 }

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -74,7 +74,7 @@ var (
 	policyFlag    = flag.String("policy", defaultPolicy, "Local OPA policy governing access.  If empty, use builtin policy.")
 	policyFile    = flag.String("policy-file", "", "Path to a file with an OPA policy.  If empty, uses --policy.")
 	hostport      = flag.String("hostport", "localhost:50042", "Where to listen for connections.")
-	debugport     = flag.String("debugport", "localhost:50044", "A separate port for http debug pages.")
+	debugport     = flag.String("debugport", "localhost:50044", "A separate port for http debug pages. Set to an empty string to disable.")
 	credSource    = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	verbosity     = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate      = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")

--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -23,9 +23,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
@@ -42,6 +45,8 @@ type runState struct {
 	credSource         string
 	tlsConfig          *tls.Config
 	hostport           string
+	debugport          string
+	debughandler       *http.ServeMux
 	policy             string
 	justification      bool
 	justificationFunc  func(string) error
@@ -160,6 +165,37 @@ func WithRawServerOption(s func(*grpc.Server)) Option {
 	})
 }
 
+// WithDebugPort opens an additional port for a http debug page.
+//
+// This is meant for humans. The format of the debug pages may change over time.
+func WithDebugPort(addr string) Option {
+	return optionFunc(func(r *runState) error {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" {
+				fmt.Fprintln(w, `<!DOCTYPE html>
+			Hi, I'm a sansshell server. Maybe you want one of the following pages.
+			<ul>
+			<li><a href="/debug/pprof">/debug/pprof</a></li>
+			<li><a href="/metrics">/metrics</a></li>
+			</ul>`)
+			} else {
+				http.NotFound(w, r)
+				return
+			}
+		})
+		mux.Handle("/metrics", promhttp.Handler())
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		r.debugport = addr
+		r.debughandler = mux
+		return nil
+	})
+}
+
 // Run takes the given context and RunState and starts up a sansshell server.
 // As this is intended to be called from main() it doesn't return errors and will instead exit on any errors.
 func Run(ctx context.Context, opts ...Option) {
@@ -172,8 +208,15 @@ func Run(ctx context.Context, opts ...Option) {
 			os.Exit(1)
 		}
 	}
-	creds, err := extractTransportCredentialsFromRunState(ctx, rs)
 
+	// If there's a debug port, we want to start it early
+	if rs.debughandler != nil {
+		go func() {
+			rs.logger.Error(http.ListenAndServe(rs.debugport, rs.debughandler), "Debug handler unexpectedly exited")
+		}()
+	}
+
+	creds, err := extractTransportCredentialsFromRunState(ctx, rs)
 	if err != nil {
 		rs.logger.Error(err, "unable to extract transport credentials from runstate", "credsource", rs.credSource)
 	}

--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -210,7 +210,7 @@ func Run(ctx context.Context, opts ...Option) {
 	}
 
 	// If there's a debug port, we want to start it early
-	if rs.debughandler != nil {
+	if rs.debughandler != nil && rs.debugport != "" {
 		go func() {
 			rs.logger.Error(http.ListenAndServe(rs.debugport, rs.debughandler), "Debug handler unexpectedly exited")
 		}()

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/subcommands v1.2.0
 	github.com/open-policy-agent/opa v0.45.0
+	github.com/prometheus/client_golang v1.13.0
 	gocloud.dev v0.27.0
 	golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
@@ -52,6 +53,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.19 // indirect
 	github.com/aws/smithy-go v1.13.3 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
@@ -64,8 +67,12 @@ require (
 	github.com/googleapis/gax-go/v2 v2.5.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.37.0 // indirect
+	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1233,6 +1233,7 @@ github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqr
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.13.0 h1:b71QUfeo5M8gq2+evJdTPfZhYMAU0uKPkyPJ7TPsloU=
+github.com/prometheus/client_golang v1.13.0/go.mod h1:vTeo+zgvILHsnnj/39Ou/1fPN5nJFOEMgftOUOmlvYQ=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -1275,6 +1276,7 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
+github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/prometheus v0.35.0/go.mod h1:7HaLx5kEPKJ0GDgbODG0fZgXbQ8K/XjZNJXQmbmgQlY=
 github.com/prometheus/prometheus v0.37.0/go.mod h1:egARUgz+K93zwqsVIAneFlLZefyGOON44WyAp4Xqbbk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=


### PR DESCRIPTION
server.WithDebugPort now allows you to start a debug port in both sansshell-server and proxy-server, currently with three things.

- Trivial index page
- /debug/pprof/ and children
- /metrics

This expands the public interface of this package, so some caution is warranted. Some notable callouts:

- There's no exposed interfaces for editing what gets displayed or adding your own pages
- There's no way to reduce the number of things being displayed if someone wants to make the debug handler less revealing

We can add more Options in the future and there's always the escape hatch of someone creating their own http server, so that seems like an acceptable tradeoff.