### PR TITLE
Fix typo in build-test.yaml

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2,7 +2,7 @@
 name: Build and Test
 on:
   push:
-    braches:
+    branches:
       - main
     tags:
       - v*


### PR DESCRIPTION
I'd misspelled branches, so we were mistakenly building and testing on every push and not only pushes to main