### PR TITLE
Add Evaluation Result to Authz Audit Logs

### DIFF
--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -87,9 +87,8 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		}
 	}
 	if input == nil {
-		errMsg := "policy input cannot be nil"
-		err := status.Error(codes.InvalidArgument, errMsg)
-		logger.V(1).Error(err, errMsg)
+		err := status.Error(codes.InvalidArgument, "policy input cannot be nil")
+		logger.V(1).Error(err, "failed to evaluate authz policy")
 		return err
 	}
 	for _, hook := range g.hooks {

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -110,11 +110,10 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		return status.Errorf(codes.Internal, "authz policy evaluation error: %v", err)
 	}
 	logger = logger.WithValues("authorizationResult", result)
+	logger.V(1).Info("authz policy evaluation result")
 	if !result {
-		logger.V(1).Info("authz policy evaluation result")
 		return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request")
 	}
-	logger.V(1).Info("authz policy evaluation result")
 
 	return nil
 }

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -114,7 +114,6 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 	if !result {
 		return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request")
 	}
-
 	return nil
 }
 

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -355,7 +355,7 @@ func NewTargetStream(ctx context.Context, target string, dialer TargetDialer, di
 		dialTimeout:   dialTimeout,
 	}
 	ts.logger = logger.WithValues("stream", ts.String())
-	ts.logger.Info("created")
+	ts.logger.Info("created target stream")
 	return ts, nil
 }
 


### PR DESCRIPTION
Add authz evaluation result to audit logs to help us understand whether a request is approved or deny.