### PR TITLE
Add session id to sansshell logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/subcommands v1.2.0
+	github.com/google/uuid v1.3.0
 	github.com/open-policy-agent/opa v0.50.2
 	github.com/prometheus/client_golang v1.14.0
 	gocloud.dev v0.29.0
@@ -62,7 +63,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -158,6 +159,8 @@ func UnaryServerLogInterceptor(logger logr.Logger) grpc.UnaryServerInterceptor {
 		if p, ok := peer.FromContext(ctx); ok {
 			l = l.WithValues("peer-address", p.Addr)
 		}
+		id := uuid.NewString()
+		l = l.WithValues("sansshell-session-id", id)
 		l = logMetadata(ctx, l)
 		l.Info("new request")
 		logCtx := logr.NewContext(ctx, l)
@@ -180,6 +183,8 @@ func StreamServerLogInterceptor(logger logr.Logger) grpc.StreamServerInterceptor
 		if p, ok := peer.FromContext(ss.Context()); ok {
 			l = l.WithValues("peer-address", p.Addr)
 		}
+		id := uuid.NewString()
+		l = l.WithValues("sansshell-session-id", id)
 		l = logMetadata(ss.Context(), l)
 		l.Info("new stream")
 		stream := &loggedStream{

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -84,7 +84,7 @@ func StreamClientLogInterceptor(logger logr.Logger) grpc.StreamClientInterceptor
 }
 
 func logMetadata(ctx context.Context, l logr.Logger) logr.Logger {
-	// Add any sansshell specific metadata to the logging we do.
+	// Add any sansshell specific metadata from incoming context to the logging we do.
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		for k, v := range md {
@@ -95,6 +95,7 @@ func logMetadata(ctx context.Context, l logr.Logger) logr.Logger {
 			}
 		}
 	}
+	// Log session ID obtained from current context
 	sessionID := ctx.Value(contextKeySansshellSessionID)
 	if sessionID == nil {
 		l.V(0).Error(errors.New("session ID is missing in context"), "unable to find session ID")
@@ -117,6 +118,7 @@ func passAlongMetadata(ctx context.Context) context.Context {
 			}
 		}
 	}
+	// Pass session ID obtained from context
 	sessionID := ctx.Value(contextKeySansshellSessionID)
 	if sessionID == nil {
 		l := logr.FromContextOrDiscard(ctx)
@@ -171,6 +173,9 @@ func (l *loggedClientStream) CloseSend() error {
 	return err
 }
 
+// getSessionIDFromIncomingCtx returns the sansshell session id from incoming context
+// if it exists. Otherwise it returns an empty string.
+// It also returns a boolean indicating whether session id exists or not.
 func getSessionIDFromIncomingCtx(ctx context.Context) (string, bool) {
 	var sessionID string
 	incomingCtx, ok := metadata.FromIncomingContext(ctx)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -20,7 +20,6 @@ package telemetry
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 
@@ -97,9 +96,7 @@ func logMetadata(ctx context.Context, l logr.Logger) logr.Logger {
 	}
 	// Log session ID obtained from current context
 	sessionID := ctx.Value(contextKeySansshellSessionID)
-	if sessionID == nil {
-		l.V(0).Error(errors.New("session ID is missing in context"), "unable to find session ID")
-	} else {
+	if sessionID != nil {
 		l = l.WithValues(sansshellSessionIDKey, sessionID.(string))
 	}
 	return l
@@ -120,10 +117,7 @@ func passAlongMetadata(ctx context.Context) context.Context {
 	}
 	// Pass session ID obtained from context
 	sessionID := ctx.Value(contextKeySansshellSessionID)
-	if sessionID == nil {
-		l := logr.FromContextOrDiscard(ctx)
-		l.V(0).Error(errors.New("session ID is missing in context"), "unable to find session ID")
-	} else {
+	if sessionID != nil {
 		ctx = metadata.AppendToOutgoingContext(ctx, sansshellSessionIDKey, sessionID.(string))
 	}
 


### PR DESCRIPTION
Attach an ID to each sansshell session, and log them.
This would make it easier to trace sansshell logs. We could find all logs generated for a session by looking for its id.