### PR TITLE
Add unit test for authorization logging

### DIFF
--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -284,7 +284,7 @@ func TestAuthzHook(t *testing.T) {
 					},
 					{
 						field:  "\"method\":\"/Foo.Bar/Foo\"",
-						errMsg: "expected logs to contain /Foo.Bar/Foo method",
+						errMsg: "expected logs to contain request method",
 					},
 				},
 			),

--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -280,7 +280,7 @@ func TestAuthzHook(t *testing.T) {
 				[]expectedLog{
 					{
 						field:  "\"principal\":{\"id\":\"admin@foo\",\"groups\":[\"group_bar\"]}}",
-						errMsg: "expected logs to contain peer principal",
+						errMsg: "this test case should pass the authz hook, so its logs should contain peer principal info which is added by the hook",
 					},
 					{
 						field:  "\"method\":\"/Foo.Bar/Foo\"",


### PR DESCRIPTION
As a followup to #207, the new tests would make sure that authz logs contain necessary fields, such as peer principal and request method.