### PR TITLE
Add a way to expose denial hints in the sansshell policies.

### DIFF
--- a/auth/opa/opa.go
+++ b/auth/opa/opa.go
@@ -71,7 +71,7 @@ func (o optionFunc) apply(opts *policyOptions) {
 	o(opts)
 }
 
-// WithAllowQuery returns an option to use `query` to evaulate the policy,
+// WithAllowQuery returns an option to use `query` to evaluate the policy,
 // instead of DefaultAuthzQuery. The supplied query should be simple evaluation
 // expressions that creates no binding, and evaluates to 'true' iff the input
 // satisfies the conditions of the policy.
@@ -81,7 +81,7 @@ func WithAllowQuery(query string) Option {
 	})
 }
 
-// WithDenialHintsQuery returns an option to use `query` to evaulate the policy
+// WithDenialHintsQuery returns an option to use `query` to evaluate the policy
 // when the AllowPolicy fails. The supplied query must be a simple evaluation
 // expression that creates no binding and evaluates to an array of strings.
 //

--- a/auth/opa/opa.go
+++ b/auth/opa/opa.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	"github.com/open-policy-agent/opa/ast"
@@ -49,12 +50,14 @@ var (
 // An AuthzPolicy performs policy checking by evaluating input against
 // a sansshell rego policy file.
 type AuthzPolicy struct {
-	query rego.PreparedEvalQuery
-	b     *bytes.Buffer
+	query            rego.PreparedEvalQuery
+	denialHintsQuery *rego.PreparedEvalQuery
+	b                *bytes.Buffer
 }
 
 type policyOptions struct {
-	query string
+	query            string
+	denialHintsQuery string
 }
 
 // An Option controls the behavior of an AuthzPolicy
@@ -75,6 +78,24 @@ func (o optionFunc) apply(opts *policyOptions) {
 func WithAllowQuery(query string) Option {
 	return optionFunc(func(o *policyOptions) {
 		o.query = query
+	})
+}
+
+// WithDenialHintsQuery returns an option to use `query` to evaulate the policy
+// when the AllowPolicy fails. The supplied query must be a simple evaluation
+// expression that creates no binding and evaluates to an array of strings.
+//
+// This can be used to give better error messages when Eval returns false.
+// With a value like data.sansshell.authz.denial_hints, you can use a policy
+// with rules like
+//
+//	denial_hints [msg] {
+//	  not allow
+//	  msg :="you need to be allowed"
+//	}
+func WithDenialHintsQuery(query string) Option {
+	return optionFunc(func(o *policyOptions) {
+		o.denialHintsQuery = query
 	})
 }
 
@@ -111,9 +132,22 @@ func NewAuthzPolicy(ctx context.Context, policy string, opts ...Option) (*AuthzP
 	if err != nil {
 		return nil, fmt.Errorf("rego: PrepareForEval() error: %w", err)
 	}
+	var denialHintsQuery *rego.PreparedEvalQuery
+	if options.denialHintsQuery != "" {
+		r := rego.New(
+			rego.Query(options.denialHintsQuery),
+			rego.ParsedModule(module),
+		)
+		hints, err := r.PrepareForEval(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("rego: denial hints PrepareForEval() error: %w", err)
+		}
+		denialHintsQuery = &hints
+	}
 	return &AuthzPolicy{
-		query: prepared,
-		b:     b,
+		query:            prepared,
+		denialHintsQuery: denialHintsQuery,
+		b:                b,
 	}, nil
 }
 
@@ -130,4 +164,41 @@ func (q *AuthzPolicy) Eval(ctx context.Context, input interface{}) (bool, error)
 		logger.V(1).Info("print statements", "buffer", q.b.String())
 	}
 	return results.Allowed(), nil
+}
+
+// DenialHints evaluates this policy using the provided input, returning an array
+// of strings with reasons for the denial. This is typically used after getting
+// a rejection from Eval to give more hints on why the rejection happened.
+// It is a no-op if opa.WithDenialHintsQuery was not used.
+func (q *AuthzPolicy) DenialHints(ctx context.Context, input interface{}) ([]string, error) {
+	if q.denialHintsQuery == nil {
+		return nil, nil
+	}
+	results, err := q.denialHintsQuery.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return nil, fmt.Errorf("authz policy evaluation error: %w", err)
+	}
+	if len(results) != 1 {
+		return nil, fmt.Errorf("expected exactly one result: %v", results)
+	}
+	if len(results[0].Bindings) != 0 {
+		return nil, fmt.Errorf("too many bindings: %v", results)
+	}
+	if len(results[0].Expressions) != 1 {
+		return nil, fmt.Errorf("expected exactly one expression: %v", results[0].Expressions)
+	}
+	vals, ok := results[0].Expressions[0].Value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("expected expression to be an array: %#v", results[0].Expressions[0].Value)
+	}
+	var hints []string
+	for _, v := range vals {
+		h, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected expression to be a string: %#v", v)
+		}
+		hints = append(hints, h)
+	}
+	sort.Strings(hints)
+	return hints, nil
 }

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -20,6 +20,7 @@ package rpcauth
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
@@ -113,7 +114,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			logger.V(1).Error(err, "failed to get hints for authz policy denial", "error", err)
 		}
 		if len(hints) > 0 {
-			return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request: %v", hints)
+			return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request: %v", strings.Join(hints, ", "))
 		} else {
 			return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request")
 		}

--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -105,14 +105,17 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 		logger.V(1).Error(err, "failed to evaluate authz policy", "input", input)
 		return status.Errorf(codes.Internal, "authz policy evaluation error: %v", err)
 	}
-	logger.V(1).Info("authz policy evaluation result", "authorizationResult", result, "input", input)
+	var hints []string
 	if !result {
 		// We've failed so let's see if we can help tell the user what might have failed.
-		hints, err := g.policy.DenialHints(ctx, input)
+		hints, err = g.policy.DenialHints(ctx, input)
 		if err != nil {
 			// We can't do much here besides log that something went wrong
 			logger.V(1).Error(err, "failed to get hints for authz policy denial", "error", err)
 		}
+	}
+	logger.V(1).Info("authz policy evaluation result", "authorizationResult", result, "input", input, "denialHints", hints)
+	if !result {
 		if len(hints) > 0 {
 			return status.Errorf(codes.PermissionDenied, "OPA policy does not permit this request: %v", strings.Join(hints, ", "))
 		} else {

--- a/cmd/proxy-server/default-policy.rego
+++ b/cmd/proxy-server/default-policy.rego
@@ -53,3 +53,12 @@ allow {
 #  some i
 #  input.peer.principal.groups[i] = "admin"
 # }
+
+# Denial reason to help show what went wrong
+denial_hints[msg] {
+	input.message.file.filename != "/etc/hosts"
+	msg := "we only proxy /etc/hosts"
+}
+denial_hints[msg] {
+	msg := "this message always shows up on errors"
+}

--- a/cmd/proxy-server/default-policy.rego
+++ b/cmd/proxy-server/default-policy.rego
@@ -59,6 +59,7 @@ denial_hints[msg] {
 	input.message.file.filename != "/etc/hosts"
 	msg := "we only proxy /etc/hosts"
 }
+# You can put multiple denial hints and all of them will be included.
 denial_hints[msg] {
 	msg := "this message always shows up on errors"
 }

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -99,11 +99,11 @@ func main() {
 	clientPolicy := util.ChoosePolicy(logger, "", *clientPolicyFlag, *clientPolicyFile)
 	ctx := logr.NewContext(context.Background(), logger)
 
+	parsed, err := opa.NewAuthzPolicy(ctx, policy, opa.WithDenialHintsQuery("data.sansshell.authz.denial_hints"))
+	if err != nil {
+		log.Fatalf("Invalid policy: %v\n", err)
+	}
 	if *validate {
-		_, err := opa.NewAuthzPolicy(ctx, policy)
-		if err != nil {
-			log.Fatalf("Invalid policy: %v\n", err)
-		}
 		fmt.Println("Policy passes.")
 		os.Exit(0)
 	}
@@ -113,7 +113,7 @@ func main() {
 
 	server.Run(ctx,
 		server.WithLogger(logger),
-		server.WithPolicy(policy),
+		server.WithParsedPolicy(parsed),
 		server.WithClientPolicy(clientPolicy),
 		server.WithCredSource(*credSource),
 		server.WithHostPort(*hostport),

--- a/cmd/proxy-server/server/server.go
+++ b/cmd/proxy-server/server/server.go
@@ -267,7 +267,7 @@ func WithDebugPort(addr string) Option {
 // This endpoint is to be scraped by a Prometheus-style metrics scraper.
 // It can be accessed at http://{addr}/metrics
 func WithMetricsPort(addr string) Option {
-	return optionFunc(func(r *runState) error {
+	return optionFunc(func(_ context.Context, r *runState) error {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
 		r.metricsport = addr

--- a/cmd/sansshell-server/default-policy.rego
+++ b/cmd/sansshell-server/default-policy.rego
@@ -63,3 +63,8 @@ allow {
 allow {
 	input.type = "Service.StatusRequest"
 }
+
+denial_hints[msg] {
+	#input.message.file.filename != "/etc/hosts"
+	msg := "we only allow /etc/hosts"
+}

--- a/cmd/sansshell-server/default-policy.rego
+++ b/cmd/sansshell-server/default-policy.rego
@@ -65,6 +65,6 @@ allow {
 }
 
 denial_hints[msg] {
-	#input.message.file.filename != "/etc/hosts"
+	input.message.file.filename != "/etc/hosts"
 	msg := "we only allow /etc/hosts"
 }

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -133,7 +133,6 @@ func main() {
 	}
 
 	if *validate {
-
 		fmt.Println("Policy passes.")
 		os.Exit(0)
 	}

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -127,11 +127,13 @@ func main() {
 	policy := util.ChoosePolicy(logger, defaultPolicy, *policyFlag, *policyFile)
 	ctx := logr.NewContext(context.Background(), logger)
 
+	parsed, err := opa.NewAuthzPolicy(ctx, policy, opa.WithDenialHintsQuery("data.sansshell.authz.denial_hints"))
+	if err != nil {
+		log.Fatalf("Invalid policy: %v\n", err)
+	}
+
 	if *validate {
-		_, err := opa.NewAuthzPolicy(ctx, policy)
-		if err != nil {
-			log.Fatalf("Invalid policy: %v\n", err)
-		}
+
 		fmt.Println("Policy passes.")
 		os.Exit(0)
 	}
@@ -140,7 +142,7 @@ func main() {
 		server.WithLogger(logger),
 		server.WithCredSource(*credSource),
 		server.WithHostPort(*hostport),
-		server.WithPolicy(policy),
+		server.WithParsedPolicy(parsed),
 		server.WithJustification(*justification),
 		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),
 		server.WithRawServerOption(func(s *grpc.Server) { channelz.RegisterChannelzServiceToServer(s) }),

--- a/server/server.go
+++ b/server/server.go
@@ -171,6 +171,9 @@ func BuildServer(opts ...Option) (*grpc.Server, error) {
 			return nil, err
 		}
 	}
+	if ss.policy == nil {
+		return nil, fmt.Errorf("policy was not provided")
+	}
 
 	authz := rpcauth.New(ss.policy, ss.authzHooks...)
 

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/Snowflake-Labs/sansshell/auth/opa"
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/services"
 	"github.com/Snowflake-Labs/sansshell/telemetry"
@@ -42,7 +43,7 @@ var (
 // Documentation provided below in each WithXXX function.
 type serveSetup struct {
 	creds              credentials.TransportCredentials
-	policy             string
+	policy             *opa.AuthzPolicy
 	logger             logr.Logger
 	authzHooks         []rpcauth.RPCAuthzHook
 	unaryInterceptors  []grpc.UnaryServerInterceptor
@@ -51,18 +52,18 @@ type serveSetup struct {
 }
 
 type Option interface {
-	apply(*serveSetup) error
+	apply(context.Context, *serveSetup) error
 }
 
-type optionFunc func(*serveSetup) error
+type optionFunc func(context.Context, *serveSetup) error
 
-func (o optionFunc) apply(s *serveSetup) error {
-	return o(s)
+func (o optionFunc) apply(ctx context.Context, s *serveSetup) error {
+	return o(ctx, s)
 }
 
 // WithCredentials applies credentials to be used by the RPC server.
 func WithCredentials(c credentials.TransportCredentials) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.creds = c
 		return nil
 	})
@@ -70,7 +71,19 @@ func WithCredentials(c credentials.TransportCredentials) Option {
 
 // WithPolicy applies an OPA policy used against incoming RPC requests.
 func WithPolicy(policy string) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(ctx context.Context, s *serveSetup) error {
+		p, err := opa.NewAuthzPolicy(ctx, policy)
+		if err != nil {
+			return err
+		}
+		s.policy = p
+		return nil
+	})
+}
+
+// WithParsedPolicy applies an already-parsed OPA policy used against incoming RPC requests.
+func WithParsedPolicy(policy *opa.AuthzPolicy) Option {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.policy = policy
 		return nil
 	})
@@ -79,7 +92,7 @@ func WithPolicy(policy string) Option {
 // WithLogger applies a logger that is used for all logging. A discard one is
 // used if none is supplied.
 func WithLogger(l logr.Logger) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.logger = l
 		return nil
 	})
@@ -87,7 +100,7 @@ func WithLogger(l logr.Logger) Option {
 
 // WithAuthzHook adds an authz hook which is checked by the installed authorizer.
 func WithAuthzHook(hook rpcauth.RPCAuthzHook) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.authzHooks = append(s.authzHooks, hook)
 		return nil
 	})
@@ -95,7 +108,7 @@ func WithAuthzHook(hook rpcauth.RPCAuthzHook) Option {
 
 // WithUnaryInterceptor adds an additional unary interceptor installed after telemetry and authz.
 func WithUnaryInterceptor(unary grpc.UnaryServerInterceptor) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.unaryInterceptors = append(s.unaryInterceptors, unary)
 		return nil
 	})
@@ -103,7 +116,7 @@ func WithUnaryInterceptor(unary grpc.UnaryServerInterceptor) Option {
 
 // WithStreamInterceptor adds an additional stream interceptor installed after telemetry and authz.
 func WithStreamInterceptor(stream grpc.StreamServerInterceptor) Option {
-	return optionFunc(func(s *serveSetup) error {
+	return optionFunc(func(_ context.Context, s *serveSetup) error {
 		s.streamInterceptors = append(s.streamInterceptors, stream)
 		return nil
 	})
@@ -112,7 +125,7 @@ func WithStreamInterceptor(stream grpc.StreamServerInterceptor) Option {
 // WithRawServerOption allows one access to the RPC Server object. Generally this is done to add additional
 // registration functions for RPC services to be done before starting the server.
 func WithRawServerOption(s func(*grpc.Server)) Option {
-	return optionFunc(func(r *serveSetup) error {
+	return optionFunc(func(_ context.Context, r *serveSetup) error {
 		r.services = append(r.services, s)
 		return nil
 	})
@@ -149,19 +162,17 @@ func getSrv() *grpc.Server {
 // registers all of the imported SansShell modules. Separating this from Serve
 // primarily facilitates testing.
 func BuildServer(opts ...Option) (*grpc.Server, error) {
+	ctx := context.Background()
 	ss := &serveSetup{
 		logger: logr.Discard(),
 	}
 	for _, o := range opts {
-		if err := o.apply(ss); err != nil {
+		if err := o.apply(ctx, ss); err != nil {
 			return nil, err
 		}
 	}
 
-	authz, err := rpcauth.NewWithPolicy(context.Background(), ss.policy, ss.authzHooks...)
-	if err != nil {
-		return nil, err
-	}
+	authz := rpcauth.New(ss.policy, ss.authzHooks...)
 
 	unary := ss.unaryInterceptors
 	unary = append(unary,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -97,6 +97,17 @@ func TestBuildServer(t *testing.T) {
 	testutil.FatalOnNoErr("empty policy", err, t)
 }
 
+func TestBuildServerWithBadPolicy(t *testing.T) {
+	// Make sure a bad policy fails
+	_, err := BuildServer(
+		WithLogger(logr.Discard()),
+		WithAuthzHook(rpcauth.HostNetHook(lis.Addr())),
+		WithPolicy("not a real policy"),
+	)
+	t.Log(err)
+	testutil.FatalOnNoErr("badly formed policy", err, t)
+}
+
 func TestServe(t *testing.T) {
 	// This test should be instant so just wait 5s and blow up
 	// any running server (which should be the last one).


### PR DESCRIPTION
A common issue when interacting with complex policies is figuring out why a user doesn't have permission to run a command. It's possible to add print statements to diagnose or to grab a copy of the input and run it against a modified local version of a policy, but this tends to be time-consuming and requires knowledge of how policy evaluation works.

This change adds a new way to help with common issues by giving a way to put failure messages into the policy. Normally policies have a single `allow` boolean that gets consulted to decide whether a command is approved. I've added a way to create an additional array of strings that gets queried on a subsequent evaluation after failure.

If you add a line like the following to the rego policy

```
denial_hints [msg] {
  not allow
  msg :="you need to be allowed"
}
```

Then rejected requests will see a failure message like

```
OPA policy does not permit this request: you need to be allowed
```

Enabling this requires passing in an option like `opa.WithDenialHintsQuery("data.sansshell.authz.denial_hints")` when creating the OPA policy.