### PR TITLE
Add missing exit on credentials failure

### DIFF
--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -247,6 +247,7 @@ func Run(ctx context.Context, opts ...Option) {
 	creds, err := extractTransportCredentialsFromRunState(ctx, rs)
 	if err != nil {
 		rs.logger.Error(err, "unable to extract transport credentials from runstate", "credsource", rs.credSource)
+		os.Exit(1)
 	}
 
 	justificationHook := rpcauth.HookIf(rpcauth.JustificationHook(rs.justificationFunc), func(input *rpcauth.RPCAuthInput) bool {


### PR DESCRIPTION
I'm fairly certain this was forgotten. Before this change, a failure to get credentials would make sansshell-server log that credentials weren't present and then use nil credentials (which won't let anything connect). Afterwards, sansshell-server will crash on this failure.

The equivalent line in sansshell-proxy has an early-exit: https://github.com/Snowflake-Labs/sansshell/blob/03aa7f4f0e5febc423ec977de820f9148b945157/cmd/proxy-server/server/server.go#L356-L359