### PR TITLE
Add a StringSliceCommaOrWhitespaceFlag

### DIFF
--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -78,10 +78,10 @@ If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
 	batchSize        = flag.Int("batch-size", 0, "If non-zero will perform the proxy->target work in batches of this size (with any remainder done at the end).")
 
 	// targets will be bound to --targets for sending a single request to N nodes.
-	targetsFlag util.StringSliceFlag
+	targetsFlag util.StringSliceCommaOrWhitespaceFlag
 
 	// outputs will be found to --outputs for directing output from a single request to N nodes.
-	outputsFlag util.StringSliceFlag
+	outputsFlag util.StringSliceCommaOrWhitespaceFlag
 )
 
 func init() {
@@ -95,8 +95,8 @@ func init() {
 	outputsFlag.Target = &[]string{}
 	targetsFlag.Target = &[]string{}
 
-	flag.Var(&targetsFlag, "targets", fmt.Sprintf("List of targets (host[:port] separated by commas) to apply RPC against. If --proxy is not set must be one entry only. If port is blank the default of %d will be used", defaultTargetPort))
-	flag.Var(&outputsFlag, "outputs", `List of output destinations (separated by commas) to direct output into.
+	flag.Var(&targetsFlag, "targets", fmt.Sprintf("List of targets (host[:port] separated by commas and/or whitespace) to apply RPC against. If --proxy is not set must be one entry only. If port is blank the default of %d will be used", defaultTargetPort))
+	flag.Var(&outputsFlag, "outputs", `List of output destinations (separated by commas and/or whitespace) to direct output into.
     Use - to indicated stdout/stderr (default if nothing else is set). Using - does not have to be repeated per target.
 	Errors will be emitted to <destination>.error separately from command/execution output which will be in the destination file.
 	NOTE: This must map 1:1 with --targets except in the '-' case.`)

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -312,6 +312,33 @@ func (s *StringSliceFlag) String() string {
 	return strings.Join(*s.Target, ",")
 }
 
+// StringSliceCommaOrWhitespaceFlag is the parsed form of a flag accepting
+// either "foo,bar,baz" or "foo bar baz" style. This is useful in cases where
+// we want to be more flexible in the input values we accept.
+type StringSliceCommaOrWhitespaceFlag struct {
+	Target *[]string
+}
+
+// Set - see flag.Value
+func (s *StringSliceCommaOrWhitespaceFlag) Set(val string) error {
+	if s.Target == nil {
+		s.Target = new([]string)
+	}
+	for _, vals := range strings.Fields(val) {
+
+		*s.Target = append(*s.Target, strings.Split(vals, ",")...)
+	}
+	return nil
+}
+
+// String - see flag.String
+func (s *StringSliceCommaOrWhitespaceFlag) String() string {
+	if s.Target == nil {
+		return ""
+	}
+	return strings.Join(*s.Target, ",")
+}
+
 // KeyValue is used below with KeyValueSliceFlag to construct foo=bar,baz=foo type of flags.
 type KeyValue struct {
 	Key   string

--- a/services/util/util_test.go
+++ b/services/util/util_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/Snowflake-Labs/sansshell/testing/testutil"
@@ -246,6 +247,58 @@ func TestStringSliceFlag(t *testing.T) {
 	}
 	if len(*flag.Target) != 3 {
 		t.Fatalf("flag should have 3 elements. Instead is %q", *flag.Target)
+	}
+}
+
+func TestStringSliceCommaOrWhitespaceFlag(t *testing.T) {
+	for _, tc := range []struct {
+		desc       string
+		input      string
+		wantTarget []string
+		wantString string
+	}{
+		{
+			desc: "empty input",
+		},
+		{
+			desc:       "simple case",
+			input:      "foo,bar,baz",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "space separated",
+			input:      "foo bar baz",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc: "newline separated",
+			input: `foo
+bar
+baz`,
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "space and comma separated",
+			input:      "foo,bar baz",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var flag StringSliceCommaOrWhitespaceFlag
+			if err := flag.Set(tc.input); err != nil {
+				t.Errorf("error from flag.Set: %v", err)
+			}
+			if got := flag.String(); got != tc.wantString {
+				t.Errorf("flag didn't set to correct value. got %s and want %s", got, tc.wantString)
+			}
+			if !reflect.DeepEqual(*flag.Target, tc.wantTarget) {
+				t.Errorf("flag parsed as %v, wanted %v", *flag.Target, tc.wantTarget)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This is a minor quality-of-life upgrade. When using sanssh, it's often convenient to pass in a list of targets that came from another source. Allowing whitespace separation makes some options involving shell commands easier because you can pass in something like `-targets $(cat newline/separated/file)`.

This is separate from StringSliceFlag to avoid breaking any use cases that want to parse comma-separated data that contains whitespace.