### PR TITLE
Make service/status handle disabled service

### DIFF
--- a/services/service/server/server_linux.go
+++ b/services/service/server/server_linux.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -236,7 +237,9 @@ func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusR
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "list_units_err"))
 		return nil, status.Errorf(codes.Internal, "systemd status error %v", err)
 	}
+	logger := logr.FromContextOrDiscard(ctx)
 	for _, u := range units {
+		logger.V(3).Info("unit name " + u.Name)
 		if u.Name == unitName {
 			return &pb.StatusReply{
 				SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,

--- a/services/service/server/server_linux.go
+++ b/services/service/server/server_linux.go
@@ -116,6 +116,7 @@ func unitStateToStatus(u dbus.UnitStatus) pb.Status {
 
 // a subset of dbus.Conn used to mock for testing
 type systemdConnection interface {
+	ListUnitsByPatternsContext(ctx context.Context, states []string, patterns []string) ([]dbus.UnitStatus, error)
 	ListUnitsContext(ctx context.Context) ([]dbus.UnitStatus, error)
 	StartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error)
 	StopUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error)
@@ -230,7 +231,7 @@ func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusR
 	// NB: ideally we'd use ListUnitsByNamesContext, but older versions of systemd
 	// do not support this method, so the most failsafe method that works on all systemd
 	// versions is to retrieve the full list of units, and filter here.
-	units, err := conn.ListUnitsContext(ctx)
+	units, err := conn.ListUnitsByPatternsContext(ctx, []string{}, []string{})
 	if err != nil {
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "list_units_err"))
 		return nil, status.Errorf(codes.Internal, "systemd status error %v", err)

--- a/services/service/server/server_linux.go
+++ b/services/service/server/server_linux.go
@@ -21,6 +21,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 
@@ -117,8 +118,7 @@ func unitStateToStatus(u dbus.UnitStatus) pb.Status {
 
 // a subset of dbus.Conn used to mock for testing
 type systemdConnection interface {
-	ListUnitsByPatternsContext(ctx context.Context, states []string, patterns []string) ([]dbus.UnitStatus, error)
-	ListUnitsFilteredContext(ctx context.Context, states []string) ([]dbus.UnitStatus, error)
+	GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error)
 	ListUnitsContext(ctx context.Context) ([]dbus.UnitStatus, error)
 	StartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error)
 	StopUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error)
@@ -208,6 +208,7 @@ func (s *server) List(ctx context.Context, req *pb.ListRequest) (*pb.ListReply, 
 // See: pb.ServiceServer.Status
 func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusReply, error) {
 	recorder := metrics.RecorderFromContextOrNoop(ctx)
+	logger := logr.FromContextOrDiscard(ctx)
 	if err := checkSupportedSystem(req.SystemType); err != nil {
 		return nil, err
 	}
@@ -230,50 +231,32 @@ func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusR
 	}
 	defer conn.Close()
 
-	// NB: ideally we'd use ListUnitsByNamesContext, but older versions of systemd
-	// do not support this method, so the most failsafe method that works on all systemd
-	// versions is to retrieve the full list of units, and filter here.
-	logger := logr.FromContextOrDiscard(ctx)
-	logger.V(3).Info("executing ListUnitsByPatternsContext")
-	units, errPattern := conn.ListUnitsByPatternsContext(ctx, []string{}, []string{})
-	if errPattern != nil {
-		logger.V(3).Info("ListUnitsByPatternsContext fails: " + errPattern.Error())
-	} else {
-		for _, u := range units {
-			logger.Info("unit name " + u.Name)
-			if u.Name == unitName {
-				return &pb.StatusReply{
-					SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,
-					ServiceStatus: &pb.ServiceStatus{
-						ServiceName: req.GetServiceName(),
-						Status:      unitStateToStatus(u),
-					},
-				}, nil
-			}
-		}
-	}
-	// ListUnitsByPatterns may not be supported in older versions of systemd. If it fails, fallback to
-	// the legacy ListUnitsFiltered
-	logger.V(3).Info("executing ListUnitsFilteredContext")
-	units, err = conn.ListUnitsFilteredContext(ctx, []string{})
+	properties, err := conn.GetUnitPropertiesContext(ctx, unitName)
 	if err != nil {
-		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "list_units_err"))
-		return nil, status.Errorf(codes.Internal, "systemd status error %v", err)
+		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "get_unit_properties_err"))
+		logger.V(3).Info("GetUnitPropertiesContext err: " + err.Error())
+		return nil, status.Errorf(codes.NotFound, "failed to get unit properties of %s", req.GetServiceName())
 	}
-	for _, u := range units {
-		logger.Info("unit name " + u.Name)
-		if u.Name == unitName {
-			return &pb.StatusReply{
-				SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,
-				ServiceStatus: &pb.ServiceStatus{
-					ServiceName: req.GetServiceName(),
-					Status:      unitStateToStatus(u),
-				},
-			}, nil
-		}
+	// cast map[string]interface{} to dbus.UnitStatus{} using json marshal + unmarshal
+	propertiesJson, err := json.Marshal(properties)
+	if err != nil {
+		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "json_marshal_err"))
+		logger.V(3).Info("failed to marshal properties: " + err.Error())
+		return nil, status.Errorf(codes.NotFound, "failed to marshal unit properties to json")
 	}
-	recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "not_found"))
-	return nil, status.Errorf(codes.NotFound, "service %s was not found", req.GetServiceName())
+	unitState := dbus.UnitStatus{}
+	if errUnmarshal := json.Unmarshal(propertiesJson, &unitState); errUnmarshal != nil {
+		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "json_unmarshal_err"))
+		logger.V(3).Info("failed to unmarshal properties: " + errUnmarshal.Error())
+		return nil, status.Errorf(codes.NotFound, "failed to marshal unit properties to json")
+	}
+	return &pb.StatusReply{
+		SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,
+		ServiceStatus: &pb.ServiceStatus{
+			ServiceName: req.GetServiceName(),
+			Status:      unitStateToStatus(unitState),
+		},
+	}, nil
 }
 
 // See: pb.ServiceServer.Action

--- a/services/service/server/server_linux.go
+++ b/services/service/server/server_linux.go
@@ -248,7 +248,7 @@ func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusR
 	if errUnmarshal := json.Unmarshal(propertiesJson, &unitState); errUnmarshal != nil {
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "json_unmarshal_err"))
 		logger.V(3).Info("failed to unmarshal properties: " + errUnmarshal.Error())
-		return nil, status.Errorf(codes.NotFound, "failed to marshal unit properties to json")
+		return nil, status.Errorf(codes.NotFound, "failed to unmarshal unit properties to json")
 	}
 	return &pb.StatusReply{
 		SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,

--- a/services/service/server/server_linux.go
+++ b/services/service/server/server_linux.go
@@ -235,20 +235,20 @@ func (s *server) Status(ctx context.Context, req *pb.StatusRequest) (*pb.StatusR
 	if err != nil {
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "get_unit_properties_err"))
 		logger.V(3).Info("GetUnitPropertiesContext err: " + err.Error())
-		return nil, status.Errorf(codes.NotFound, "failed to get unit properties of %s", req.GetServiceName())
+		return nil, status.Errorf(codes.Internal, "failed to get unit properties of %s", req.GetServiceName())
 	}
 	// cast map[string]interface{} to dbus.UnitStatus{} using json marshal + unmarshal
 	propertiesJson, err := json.Marshal(properties)
 	if err != nil {
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "json_marshal_err"))
 		logger.V(3).Info("failed to marshal properties: " + err.Error())
-		return nil, status.Errorf(codes.NotFound, "failed to marshal unit properties to json")
+		return nil, status.Errorf(codes.Internal, "failed to marshal unit properties to json")
 	}
 	unitState := dbus.UnitStatus{}
 	if errUnmarshal := json.Unmarshal(propertiesJson, &unitState); errUnmarshal != nil {
 		recorder.CounterOrLog(ctx, serviceStatusFailureCounter, 1, attribute.String("reason", "json_unmarshal_err"))
 		logger.V(3).Info("failed to unmarshal properties: " + errUnmarshal.Error())
-		return nil, status.Errorf(codes.NotFound, "failed to unmarshal unit properties to json")
+		return nil, status.Errorf(codes.Internal, "failed to unmarshal unit properties to json")
 	}
 	return &pb.StatusReply{
 		SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,

--- a/services/service/server/server_linux_test.go
+++ b/services/service/server/server_linux_test.go
@@ -290,7 +290,7 @@ func TestStatus(t *testing.T) {
 			want: &pb.StatusReply{
 				SystemType: pb.SystemType_SYSTEM_TYPE_SYSTEMD,
 				ServiceStatus: &pb.ServiceStatus{
-					ServiceName: "foo.service",
+					ServiceName: "foo",
 					Status:      pb.Status_STATUS_UNKNOWN,
 				},
 			},

--- a/services/service/server/server_linux_test.go
+++ b/services/service/server/server_linux_test.go
@@ -98,6 +98,10 @@ var (
 
 type listConn []dbus.UnitStatus
 
+func (l listConn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
+	return nil, notImplementedError
+}
+
 func (l listConn) ListUnitsContext(context.Context) ([]dbus.UnitStatus, error) {
 	return l, nil
 }
@@ -367,6 +371,9 @@ type actionConn struct {
 	reloadErr error
 }
 
+func (a actionConn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
+	return nil, nil
+}
 func (a actionConn) ListUnitsContext(context.Context) ([]dbus.UnitStatus, error) {
 	return nil, nil
 }

--- a/services/service/server/server_linux_test.go
+++ b/services/service/server/server_linux_test.go
@@ -410,7 +410,7 @@ type actionConn struct {
 }
 
 func (a actionConn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
-	return nil, nil
+	return nil, notImplementedError
 }
 func (a actionConn) ListUnitsContext(context.Context) ([]dbus.UnitStatus, error) {
 	return nil, nil

--- a/services/service/server/server_linux_test.go
+++ b/services/service/server/server_linux_test.go
@@ -223,6 +223,11 @@ func TestList(t *testing.T) {
 type getConn []map[string]interface{}
 
 func (g getConn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
+	for _, u := range g {
+		if u["Name"] == unit || u["Name"].(string)+".service" == unit {
+			return u, nil
+		}
+	}
 	return nil, nil
 }
 func (g getConn) ListUnitsContext(context.Context) ([]dbus.UnitStatus, error) {
@@ -263,7 +268,7 @@ func TestStatus(t *testing.T) {
 				ServiceName: "foo",
 			},
 			want:    nil,
-			errFunc: wantStatusErr(codes.Internal, "sentinel"),
+			errFunc: wantStatusErr(codes.Internal, ""),
 		},
 		{
 			name:    "missing service",

--- a/services/service/server/server_linux_test.go
+++ b/services/service/server/server_linux_test.go
@@ -36,6 +36,10 @@ import (
 // errConn is a systemConnection that returns errors for all methods
 type errConn string
 
+func (e errConn) GetUnitPropertiesContext(ctx context.Context, unit string) (map[string]interface{}, error) {
+	return nil, errors.New(string(e))
+}
+
 func (e errConn) ListUnitsContext(context.Context) ([]dbus.UnitStatus, error) {
 	return nil, errors.New(string(e))
 }


### PR DESCRIPTION
# Context
Sansshell returns "service not found" when we try to get status of a disabled service. This is due to `ListUnitsContext` not listing disabled services: https://github.com/coreos/go-systemd/blob/v22.5.0/dbus/methods.go#L452.
```
$ ./sanssh --credential-source flags --targets localhost:55001 service status sansshell-server
target localhost:55001 [0] error: rpc error: code = NotFound desc = service sansshell-server was not found
```
Ideally it should be returning something like `status: disabled` instead of not found.


In this PR I'm replacing `ListUnitsContext` with `GetUnitPropertiesContext` which can operate on any services regardless of their status.

Service status can be inferred from UnitProperties, because UnitProperties include `LoadState`, `ActiveState`, and `SubState` which determine the overall service status. 

# Testing
Active service:
```
$ ./sanssh --credential-source flags --targets localhost:55001 service status nginx
[systemd] nginx : running
$ ./sanssh --credential-source flags --targets localhost:55001 service status rsyslog
[systemd] rsyslog : running
```
Disabled service:
```
$ ./sanssh --credential-source flags --targets localhost:55001 service status sansshell-server
[systemd] sansshell-server : stopped
```
Non-existent service:
```
$ ./sanssh --credential-source flags --targets localhost:55001 service status sansshell-servers
[systemd] sansshell-servers : unknown
$ ./sanssh --credential-source flags --targets localhost:55001 service status bob
[systemd] bob : unknown
```