### PR TITLE
Fix localfile metric name

### DIFF
--- a/services/localfile/server/localfile.go
+++ b/services/localfile/server/localfile.go
@@ -77,7 +77,7 @@ var (
 		Description: "number of failures when performing localfile.Write"}
 	localfileCopyFailureCounter = metrics.MetricDefinition{Name: "actions_localfile_copy_failure",
 		Description: "number of failures when performing localfile.Copy"}
-	localfileListFailureCounter = metrics.MetricDefinition{Name: "actions_localfile_copy_failure",
+	localfileListFailureCounter = metrics.MetricDefinition{Name: "actions_localfile_list_failure",
 		Description: "number of failures when performing localfile.List"}
 	localfileRmFailureCounter = metrics.MetricDefinition{Name: "actions_localfile_rm_failure",
 		Description: "number of failures when performing localfile.Rm"}


### PR DESCRIPTION
I did a copy-paste error. Metric name for `localfile.List` should be `actions_localfile_list`.