### PR TITLE
Fix symlink subcommand name

### DIFF
--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -237,7 +237,7 @@ func (p *readlinkCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inte
 type symlinkCmd struct {
 }
 
-func (*symlinkCmd) Name() string { return "readlink" }
+func (*symlinkCmd) Name() string { return "symlink" }
 func (*symlinkCmd) Synopsis() string {
 	return "Create a symbolic link."
 }


### PR DESCRIPTION
This fixes a mistake I introduced in the cli in https://github.com/Snowflake-Labs/sansshell/pull/211. I had accidentally used the same subcommand name for both the `readlink` and `symlink` calls