### PR TITLE
Export CmdOptions for unit testing 

### DIFF
--- a/services/util/util.go
+++ b/services/util/util.go
@@ -59,7 +59,7 @@ type CommandRun struct {
 }
 
 // A builder pattern for Options so it's easy to add various ones (such as dropping permissions, etc).
-type cmdOptions struct {
+type CmdOptions struct {
 	failOnStderr bool
 	stdoutMax    uint
 	stderrMax    uint
@@ -71,12 +71,12 @@ type cmdOptions struct {
 // Option will run the apply operation to change required checking/state
 // before executing RunCommand.
 type Option interface {
-	apply(*cmdOptions)
+	apply(*CmdOptions)
 }
 
-type optionfunc func(*cmdOptions)
+type optionfunc func(*CmdOptions)
 
-func (f optionfunc) apply(opts *cmdOptions) {
+func (f optionfunc) apply(opts *CmdOptions) {
 	f(opts)
 }
 
@@ -86,7 +86,7 @@ func (f optionfunc) apply(opts *cmdOptions) {
 // so if some run does that's suspect. Up to callers to decide as some tools (yum...) like to emit
 // stderr as debugging as they run.
 func FailOnStderr() Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.failOnStderr = true
 	})
 }
@@ -94,7 +94,7 @@ func FailOnStderr() Option {
 // StdoutMax is an option where the command run will limit output buffered from stdout to this
 // many bytes before truncating.
 func StdoutMax(max uint) Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.stdoutMax = max
 	})
 
@@ -103,21 +103,21 @@ func StdoutMax(max uint) Option {
 // StderrMax is an option where the command run will limit output buffered from stdout to this
 // many bytes before truncating.
 func StderrMax(max uint) Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.stderrMax = max
 	})
 }
 
 // CommandUser is an option which sets the uid for the Command to run as.
 func CommandUser(uid uint32) Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.uid = uid
 	})
 }
 
 // CommandGroup is an option which sets the gid for the Command to run as.
 func CommandGroup(gid uint32) Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.gid = gid
 	})
 }
@@ -125,7 +125,7 @@ func CommandGroup(gid uint32) Option {
 // EnvVar is an option which sets an environment variable for the sub-processes.
 // evar should be of the form foo=bar
 func EnvVar(evar string) Option {
-	return optionfunc(func(o *cmdOptions) {
+	return optionfunc(func(o *CmdOptions) {
 		o.env = append(o.env, evar)
 	})
 }
@@ -215,7 +215,7 @@ func RunCommand(ctx context.Context, bin string, args []string, opts ...Option) 
 
 	euid := uint32(os.Geteuid())
 	gid := uint32(os.Getgid())
-	options := &cmdOptions{
+	options := &CmdOptions{
 		stdoutMax: DefRunBufLimit,
 		stderrMax: DefRunBufLimit,
 		uid:       euid,

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -63,7 +63,7 @@ type CmdOptions struct {
 	failOnStderr bool
 	stdoutMax    uint
 	stderrMax    uint
-	env          []string
+	Env          []string
 	uid          uint32
 	gid          uint32
 }
@@ -126,7 +126,7 @@ func CommandGroup(gid uint32) Option {
 // evar should be of the form foo=bar
 func EnvVar(evar string) Option {
 	return optionfunc(func(o *CmdOptions) {
-		o.env = append(o.env, evar)
+		o.Env = append(o.Env, evar)
 	})
 }
 
@@ -238,7 +238,7 @@ func RunCommand(ctx context.Context, bin string, args []string, opts ...Option) 
 	// Set to an empty slice to get an empty environment. Nil means inherit.
 	cmd.Env = []string{}
 	// Now append any we received.
-	cmd.Env = append(cmd.Env, options.env...)
+	cmd.Env = append(cmd.Env, options.Env...)
 
 	// Set uid/gid if needed for the sub-process to run under.
 	// Only do this if it's different than our current ones since

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -71,12 +71,12 @@ type CmdOptions struct {
 // Option will run the apply operation to change required checking/state
 // before executing RunCommand.
 type Option interface {
-	apply(*CmdOptions)
+	Apply(*CmdOptions)
 }
 
 type optionfunc func(*CmdOptions)
 
-func (f optionfunc) apply(opts *CmdOptions) {
+func (f optionfunc) Apply(opts *CmdOptions) {
 	f(opts)
 }
 
@@ -222,7 +222,7 @@ func RunCommand(ctx context.Context, bin string, args []string, opts ...Option) 
 		gid:       gid,
 	}
 	for _, opt := range opts {
-		opt.apply(options)
+		opt.Apply(options)
 	}
 
 	cmd := exec.CommandContext(ctx, bin, args...)


### PR DESCRIPTION
# Problem
It's currently impossible to unit test functions that produce `Option` because of the following reasons:
1. `Option` can't be inspected / compared to another `Option`. The only way to test an `Option` is to apply it to a `cmdOptions` and inspect its values.
2. `apply` method of `Option`, and `cmdOptions` struct is not exported

# Changes
Export `Apply` method, `CmdOptions` and `Env` field, so that `Env` value can be inspected from another package.
