### PR TITLE
Add helper function to compare Options

### DIFF
--- a/services/util/util.go
+++ b/services/util/util.go
@@ -89,7 +89,7 @@ func OptionsEqual(a, b Option) bool {
 	a.apply(aCmdOptions)
 	b.apply(bCmdOptions)
 
-	return cmp.Equal(aCmdOptions, bCmdOptions)
+	return cmp.Equal(aCmdOptions, bCmdOptions, cmp.AllowUnexported(cmdOptions{}))
 }
 
 // FailOnStderr is an option where the command will return an error if any output appears on stderr

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -92,6 +92,22 @@ func OptionsEqual(a, b Option) bool {
 	return cmp.Equal(aCmdOptions, bCmdOptions, cmp.AllowUnexported(cmdOptions{}))
 }
 
+// OptionsEqual returns true if the results of applying all elements of both Option slices on
+// an empty cmdOptions are equal
+func OptionSlicesEqual(a, b []Option) bool {
+	aCmdOptions := &cmdOptions{}
+	bCmdOptions := &cmdOptions{}
+
+	for _, opt := range a {
+		opt.apply(aCmdOptions)
+	}
+	for _, opt := range b {
+		opt.apply(bCmdOptions)
+	}
+
+	return cmp.Equal(aCmdOptions, bCmdOptions, cmp.AllowUnexported(cmdOptions{}))
+}
+
 // FailOnStderr is an option where the command will return an error if any output appears on stderr
 // regardless of exit code. As we're often parsing the text output of specific commands as root
 // this is a sanity check we're getting expected output. i.e. ps never returns anything on stderr

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -81,8 +81,7 @@ func (f optionfunc) apply(opts *cmdOptions) {
 	f(opts)
 }
 
-// OptionsEqual returns true if the results of applying both Options on
-// an empty cmdOptions are equal
+// OptionsEqual returns true if the results of applying both Options are equal
 func OptionsEqual(a, b Option) bool {
 	aCmdOptions := &cmdOptions{}
 	bCmdOptions := &cmdOptions{}
@@ -92,8 +91,7 @@ func OptionsEqual(a, b Option) bool {
 	return cmp.Equal(aCmdOptions, bCmdOptions, cmp.AllowUnexported(cmdOptions{}))
 }
 
-// OptionsEqual returns true if the results of applying all elements of both Option slices on
-// an empty cmdOptions are equal
+// OptionsEqual returns true if the results of applying all elements of both Option slices are equal
 func OptionSlicesEqual(a, b []Option) bool {
 	aCmdOptions := &cmdOptions{}
 	bCmdOptions := &cmdOptions{}

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -78,6 +79,17 @@ type optionfunc func(*cmdOptions)
 
 func (f optionfunc) apply(opts *cmdOptions) {
 	f(opts)
+}
+
+// OptionsEqual returns true if the results of applying both Options on
+// an empty cmdOptions are equal
+func OptionsEqual(a, b Option) bool {
+	aCmdOptions := &cmdOptions{}
+	bCmdOptions := &cmdOptions{}
+	a.apply(aCmdOptions)
+	b.apply(bCmdOptions)
+
+	return cmp.Equal(aCmdOptions, bCmdOptions)
 }
 
 // FailOnStderr is an option where the command will return an error if any output appears on stderr

--- a/services/util/util_test.go
+++ b/services/util/util_test.go
@@ -337,3 +337,43 @@ func TestIntSliceFlag(t *testing.T) {
 		t.Fatal("didn't get error from bad flag set as we should")
 	}
 }
+
+func TestOptionsEqual(t *testing.T) {
+	for _, tc := range []struct {
+		optionA        Option
+		optionB        Option
+		expectedResult bool
+	}{
+		{
+			optionA:        EnvVar(""),
+			optionB:        EnvVar(""),
+			expectedResult: true,
+		},
+		{
+			optionA:        FailOnStderr(),
+			optionB:        FailOnStderr(),
+			expectedResult: true,
+		},
+		{
+			optionA:        EnvVar("SANSSHELL_PROXY=sansshell.com"),
+			optionB:        EnvVar("SANSSHELL_PROXY=sansshell.com"),
+			expectedResult: true,
+		},
+		{
+			optionA:        EnvVar(""),
+			optionB:        EnvVar("FOO=false"),
+			expectedResult: false,
+		},
+		{
+			optionA:        CommandGroup(1),
+			optionB:        CommandUser(2),
+			expectedResult: false,
+		},
+	} {
+		tc := tc
+		result := OptionsEqual(tc.optionA, tc.optionB)
+		if result != tc.expectedResult {
+			t.Fatalf("expected %v, got %v", tc.expectedResult, result)
+		}
+	}
+}

--- a/services/util/util_test.go
+++ b/services/util/util_test.go
@@ -338,6 +338,51 @@ func TestIntSliceFlag(t *testing.T) {
 	}
 }
 
+func TestOptionsSliceEqual(t *testing.T) {
+	for _, tc := range []struct {
+		optionA        []Option
+		optionB        []Option
+		expectedResult bool
+		name           string
+	}{
+		{
+			name:           "multiple EnvVars",
+			optionA:        []Option{EnvVar("A=A"), EnvVar("B=B")},
+			optionB:        []Option{EnvVar("A=A"), EnvVar("B=B")},
+			expectedResult: true,
+		},
+		{
+			name:           "should be true because FailOnStdErr is idempotent",
+			optionA:        []Option{FailOnStderr(), FailOnStderr()},
+			optionB:        []Option{FailOnStderr()},
+			expectedResult: true,
+		},
+		{
+			name:           "Ordering of idempotent funcs shouldn't matter",
+			optionA:        []Option{StdoutMax(3), EnvVar("A=A")},
+			optionB:        []Option{EnvVar("A=A"), StdoutMax(3)},
+			expectedResult: true,
+		},
+		{
+			name:           "EnvVar ordering does matter",
+			optionA:        []Option{EnvVar("A=A"), EnvVar("B=B")},
+			optionB:        []Option{EnvVar("B=B"), EnvVar("A=A")},
+			expectedResult: false,
+		},
+		{
+			optionA:        []Option{CommandGroup(1)},
+			optionB:        []Option{CommandUser(2), EnvVar("FOO=BAR")},
+			expectedResult: false,
+		},
+	} {
+		tc := tc
+		result := OptionSlicesEqual(tc.optionA, tc.optionB)
+		if result != tc.expectedResult {
+			t.Fatalf("test %s failed: expected %v, got %v", tc.name, tc.expectedResult, result)
+		}
+	}
+}
+
 func TestOptionsEqual(t *testing.T) {
 	for _, tc := range []struct {
 		optionA        Option


### PR DESCRIPTION
# Problem
It's currently impossible to unit test functions that produce Option because Option can't be inspected / compared to another Option. The only way to test an Option is to apply it to a cmdOptions and inspect its values.

# Solution
Add helper function `OptionsEqual` and `OptionSlicesEqual` to compare the results of applying two Options.