### PR TITLE
Exit early on empty input in prefix writer.

### DIFF
--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -85,6 +85,11 @@ type prefixWriter struct {
 }
 
 func (p *prefixWriter) Write(b []byte) (n int, err error) {
+	// Exit early if we're not writing any bytes
+	if len(b) == 0 {
+		return 0, nil
+	}
+
 	// Keep track of the size of the incoming buf as we'll print more
 	// but clients want to know we wrote what they asked for.
 	tot := len(b)

--- a/cmd/sanssh/client/client_test.go
+++ b/cmd/sanssh/client/client_test.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPrefixWriter(t *testing.T) {
+
+	for _, tc := range []struct {
+		desc   string
+		inputs []string
+		output string
+	}{
+		{
+			desc:   "Basic input",
+			inputs: []string{"Hello world\n"},
+			output: "prefix: Hello world\n",
+		},
+		{
+			desc:   "Multiple writes for single line",
+			inputs: []string{"Hello ", "world\n"},
+			output: "prefix: Hello world\n",
+		},
+		{
+			desc:   "Two lines, single write",
+			inputs: []string{"Hello\nworld\n"},
+			output: "prefix: Hello\nprefix: world\n",
+		},
+		{
+			desc:   "Two lines, multiple writes",
+			inputs: []string{"Hello\n", "world\n"},
+			output: "prefix: Hello\nprefix: world\n",
+		},
+		{
+			desc:   "Three lines, single write",
+			inputs: []string{"Hello\nworld\n\n"},
+			output: "prefix: Hello\nprefix: world\nprefix: \n",
+		},
+		{
+			desc:   "Empty input",
+			inputs: []string{""},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := &prefixWriter{
+				start:  true,
+				dest:   &buf,
+				prefix: []byte("prefix: "),
+			}
+
+			for _, i := range tc.inputs {
+				if _, err := writer.Write([]byte(i)); err != nil {
+					t.Error(err)
+				}
+			}
+			got := buf.String()
+			if got != tc.output {
+				t.Errorf("got %q, want %q", got, tc.output)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This fixes a crash with a signature like

```
panic: runtime error: slice bounds out of range [:-1] [recovered]
        panic: runtime error: slice bounds out of range [:-1]
```

The issue is

```
	if n := bytes.LastIndex(b, []byte{'\n'}); n == len(b)-1 {
		p.start = true
		b = b[:len(b)-1]
	}
```

bytes.LastIndex returns -1 when the bytes aren't found and len(b)-1 is -1 when the array is empty, so -1==-1 and things go boom when we try to index into the empty slice.

I've added a new test to more thoroughly test the prefix writer.