### PR TITLE
update: uncomment fdb services to sansshell

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -54,7 +54,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/service"
 	_ "github.com/Snowflake-Labs/sansshell/services/sysinfo"
 
-	//_ "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
 
 	// Import the sansshell server code so we can use Version.
 	ssserver "github.com/Snowflake-Labs/sansshell/services/sansshell/server"

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -54,7 +54,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/service"
 	_ "github.com/Snowflake-Labs/sansshell/services/sysinfo"
 
-	_ "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/server"
 
 	// Import the sansshell server code so we can use Version.
 	ssserver "github.com/Snowflake-Labs/sansshell/services/sansshell/server"

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/ansible/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/dns/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/exec/client"
+	_ "github.com/Snowflake-Labs/sansshell/services/fdb/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/localfile/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/packages/client"
@@ -51,7 +52,6 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/sansshell/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/service/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/sysinfo/client"
-	//_ "github.com/Snowflake-Labs/sansshell/services/fdb/client" // To get FDB modules uncomment this line.
 )
 
 const (

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/cmd/sansshell-server/server"
 	"github.com/Snowflake-Labs/sansshell/cmd/util"
+	ssutil "github.com/Snowflake-Labs/sansshell/services/util"
 	"github.com/Snowflake-Labs/sansshell/telemetry/metrics"
 
 	// Import the server modules you want to expose, they automatically register
@@ -58,7 +59,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/dns/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/exec/server"
 
-	fdbserver "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
+	fdbserver "github.com/Snowflake-Labs/sansshell/services/fdb/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/localfile/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/power/server"
@@ -88,17 +89,16 @@ var (
 	justification = flag.Bool("justification", false, "If true then justification (which is logged and possibly validated) must be passed along in the client context Metadata with the key '"+rpcauth.ReqJustKey+"'")
 	version       bool
 
-	//fdbCLIEnvList ssutil.StringSliceFlag
+	fdbCLIEnvList ssutil.StringSliceFlag
 )
 
 func init() {
 	flag.StringVar(&fdbserver.FDBCLI, "fdbcli", "/usr/bin/fdbcli", "Path to fdbcli binary. API assumes version 7.1. Older versions may not implement some commands.")
-	// Uncomment below to bind FDB flags.
-	//flag.StringVar(&fdbserver.FDBCLIUser, "fdbcli-user", "fdbuser", "User to change to when running fdbcli")
-	//flag.StringVar(&fdbserver.FDBCLIGroup, "fdbcli-group", "fdbgroup", "Group to change to when running fdbcli")
-	//fdbCLIEnvList.Target = &fdbserver.FDBCLIEnvList
-	//*fdbCLIEnvList.Target = append(*fdbCLIEnvList.Target, "SOME_ENV_VAR") // To set a default
-	//flag.Var(&fdbCLIEnvList, "fdbcli-env-list", "List of environment variable names (separated by comma) to retain before fork/exec'ing fdbcli")
+	flag.StringVar(&fdbserver.FDBCLIUser, "fdbcli-user", "", "User to change to when running fdbcli")
+	flag.StringVar(&fdbserver.FDBCLIGroup, "fdbcli-group", "", "Group to change to when running fdbcli")
+	fdbCLIEnvList.Target = &fdbserver.FDBCLIEnvList
+	*fdbCLIEnvList.Target = append(*fdbCLIEnvList.Target, "") // To set a default
+	flag.Var(&fdbCLIEnvList, "fdbcli-env-list", "List of environment variable names (separated by comma) to retain before fork/exec'ing fdbcli")
 
 	flag.StringVar(&mtlsFlags.ClientCertFile, "client-cert", mtlsFlags.ClientCertFile, "Path to this client's x509 cert, PEM format")
 	flag.StringVar(&mtlsFlags.ClientKeyFile, "client-key", mtlsFlags.ClientKeyFile, "Path to this client's key")

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -58,7 +58,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/dns/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/exec/server"
 
-	//fdbserver "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
+	fdbserver "github.com/Snowflake-Labs/sansshell/services/fdb/server" // To get FDB modules uncomment this line.
 	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/localfile/server"
 	_ "github.com/Snowflake-Labs/sansshell/services/power/server"
@@ -92,8 +92,8 @@ var (
 )
 
 func init() {
+	flag.StringVar(&fdbserver.FDBCLI, "fdbcli", "/usr/bin/fdbcli", "Path to fdbcli binary. API assumes version 7.1. Older versions may not implement some commands.")
 	// Uncomment below to bind FDB flags.
-	//flag.StringVar(&fdbserver.FDBCLI, "fdbcli", "/some/path/fdbcli", "Path to fdbcli binary. API assumes version 7.1. Older versions may not implement some commands.")
 	//flag.StringVar(&fdbserver.FDBCLIUser, "fdbcli-user", "fdbuser", "User to change to when running fdbcli")
 	//flag.StringVar(&fdbserver.FDBCLIGroup, "fdbcli-group", "fdbgroup", "Group to change to when running fdbcli")
 	//fdbCLIEnvList.Target = &fdbserver.FDBCLIEnvList


### PR DESCRIPTION
Uncomment lines of code about importing FDB servers to Sansshell client & server
Note: 

- Still leave some codes like setting FDBCLIUser, FDBCLIGroup or FDBCLIEnvList commented, because they can be easily changed or ignored by users.
- Main purpose for this update is to make FDB service visible to users in this repo so that we don't need to comment or uncomment over and over again.