### PR TITLE
Change directory for temporary files

### DIFF
--- a/services/fdb/server/conf.go
+++ b/services/fdb/server/conf.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -124,7 +125,7 @@ func init() {
 }
 
 func atomicSaveTo(f *ini.File, filename string) error {
-	tf, err := os.CreateTemp("", "fdb_conf")
+	tf, err := os.CreateTemp(filepath.Dir(filename), "fdb_conf")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
atomicSaveTo is implemented via writing a file to a temporary directory, then renaming the file. Renaming is an atomic operation on linux as long as the source and destination are on the same filesystem partition.

The current code leaves the directory unspecified, which defaults to /tmp. If /tmp is on a different partition (like tmpfs or a bind-mount), the later rename will fail. Using the same directory as the final file should be much more likely to succeed.