### PR TITLE
Add idle timeout and dial timeout

### DIFF
--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -189,16 +189,17 @@ func (t *clientStreamWithTimeout) RecvMsg(m interface{}) error {
 	case err := <-errCh:
 		return err
 	case <-ctx.Done():
-		err := ctx.Err()
-		if err == context.DeadlineExceeded {
-			err = fmt.Errorf("connection closed due to no activity after %s: %v", t.timeout, err)
-		}
+
 		select {
-		// if there's any err in errCh, append it to err
+		// if there's any err in errCh, just return it
 		case errRecv := <-errCh:
-			return fmt.Errorf("%s - %s", err, errRecv)
+			return errRecv
 		// otherwise just return err
 		default:
+			err := ctx.Err()
+			if err == context.DeadlineExceeded {
+				return fmt.Errorf("connection closed due to no activity after %s: %v", t.timeout, err)
+			}
 			return err
 		}
 	}

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -295,7 +295,7 @@ func Run(ctx context.Context, rs RunState) {
 			fmt.Fprintf(os.Stderr, "Could not connect to proxy %q node(s) in batch %d: %v\n", rs.Proxy, i, err)
 			os.Exit(1)
 		}
-		conn.IdleTimeout = &rs.IdleTimeout // is there a better way to do this? maybe via option?
+		conn.IdleTimeout = &rs.IdleTimeout // TODO(elinardi): make idleTimeout an option to proxy.DialContext() and set conn.IdleTimeout there
 		state.Conn = conn
 		state.Out = output[i*rs.BatchSize : rs.BatchSize*(i+1)]
 		state.Err = errors[i*rs.BatchSize : rs.BatchSize*(i+1)]
@@ -314,7 +314,7 @@ func Run(ctx context.Context, rs RunState) {
 			fmt.Fprintf(os.Stderr, "Could not connect to proxy %q node(s) in last batch: %v\n", rs.Proxy, err)
 			os.Exit(1)
 		}
-		conn.IdleTimeout = &rs.IdleTimeout // is there a better way to do this? maybe via option?
+		conn.IdleTimeout = &rs.IdleTimeout // TODO(elinardi): make idleTimeout an option to proxy.DialContext() and set conn.IdleTimeout there
 		state.Conn = conn
 		state.Out = output[batchCnt*rs.BatchSize:]
 		state.Err = errors[batchCnt*rs.BatchSize:]

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
 
+	cmdUtil "github.com/Snowflake-Labs/sansshell/cmd/util"
 	"github.com/Snowflake-Labs/sansshell/services/util"
 )
 
@@ -258,7 +259,8 @@ func Run(ctx context.Context, rs RunState) {
 		// as often one wants to correlate specific output back to a given target and there's no guarentee the
 		// output will have this information in it. So instead supply it as metadata via the filename.
 		for i, t := range rs.Targets {
-			rs.Outputs = append(rs.Outputs, filepath.Join(rs.OutputsDir, fmt.Sprintf("%d-%s", i, t)))
+			targetName := cmdUtil.StripTimeout(t)
+			rs.Outputs = append(rs.Outputs, filepath.Join(rs.OutputsDir, fmt.Sprintf("%d-%s", i, targetName)))
 		}
 		dir = rs.OutputsDir
 	} else {
@@ -330,10 +332,11 @@ func Run(ctx context.Context, rs RunState) {
 
 	makeWriter := func(prefix bool, i int, dest io.Writer) io.Writer {
 		if prefix {
+			targetName := cmdUtil.StripTimeout(rs.Targets[i])
 			dest = &prefixWriter{
 				start:  true,
 				dest:   dest,
-				prefix: []byte(fmt.Sprintf("%d-%s: ", i, rs.Targets[i])),
+				prefix: []byte(fmt.Sprintf("%d-%s: ", i, targetName)),
 			}
 		}
 		return dest

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -64,8 +64,7 @@ type RunState struct {
 	// CredSource is a registered credential source with the mtls package.
 	CredSource string
 	// IdleTimeout is the time duration to wait before closing an idle connection.
-	// If no messages are received within this timeframe, connection will be terminated.
-	// For streaming RPCs, if this is not set, connection will stay open until canceled.
+	// If no messages are sent/received within this timeframe, connection will be terminated.
 	IdleTimeout time.Duration
 	// ClientPolicy is an optional OPA policy for determining outbound decisions.
 	ClientPolicy string

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -308,14 +308,14 @@ func Run(ctx context.Context, rs RunState) {
 	ops := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 	}
-	// add timeout
+	if clientAuthz != nil {
+		ops = append(ops, grpc.WithStreamInterceptor(clientAuthz.AuthorizeClientStream))
+	}
+	// timeout interceptor should be the last item in ops so that it's executed first.
 	ops = append(ops,
 		grpc.WithStreamInterceptor(StreamClientTimeoutInterceptor(rs.IdleTimeout)),
 		grpc.WithUnaryInterceptor(UnaryClientTimeoutInterceptor(rs.IdleTimeout)),
 	)
-	if clientAuthz != nil {
-		ops = append(ops, grpc.WithStreamInterceptor(clientAuthz.AuthorizeClientStream))
-	}
 
 	state := &util.ExecuteState{
 		Dir: dir,

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -307,14 +307,14 @@ func Run(ctx context.Context, rs RunState) {
 	ops := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 	}
-	if clientAuthz != nil {
-		ops = append(ops, grpc.WithStreamInterceptor(clientAuthz.AuthorizeClientStream))
-	}
 	// add timeout
 	ops = append(ops,
 		grpc.WithStreamInterceptor(StreamClientTimeoutInterceptor(rs.IdleTimeout)),
 		grpc.WithUnaryInterceptor(UnaryClientTimeoutInterceptor(rs.IdleTimeout)),
 	)
+	if clientAuthz != nil {
+		ops = append(ops, grpc.WithStreamInterceptor(clientAuthz.AuthorizeClientStream))
+	}
 
 	state := &util.ExecuteState{
 		Dir: dir,

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -156,13 +156,13 @@ func (t *clientStreamWithTimeout) SendMsg(m interface{}) error {
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
 	errCh := make(chan error, 1)
-	doneCh := make(chan bool, 1)
+	doneCh := make(chan struct{}, 1)
 	go func() {
 		err := t.ClientStream.SendMsg(m)
 		if err != nil {
 			errCh <- err
 		}
-		doneCh <- true
+		close(doneCh)
 	}()
 	var errSend error
 	select {
@@ -182,13 +182,13 @@ func (t *clientStreamWithTimeout) RecvMsg(m interface{}) error {
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
 	errCh := make(chan error, 1)
-	doneCh := make(chan bool, 1)
+	doneCh := make(chan struct{}, 1)
 	go func() {
 		err := t.ClientStream.RecvMsg(m)
 		if err != nil {
 			errCh <- err
 		}
-		doneCh <- true
+		close(doneCh)
 	}()
 	var errRecv error
 	select {

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -62,14 +62,16 @@ const (
 )
 
 var (
-	defaultTimeout = 30 * time.Second
+	defaultDialTimeout = 30 * time.Second
+	defaultIdleTimeout = 15 * time.Minute
 
 	proxyAddr = flag.String("proxy", "", fmt.Sprintf(
 		`Address (host[:port]) to contact for proxy to sansshell-server.
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
-	timeout          = flag.Duration("timeout", defaultTimeout, "How long to wait for the command to complete")
+	dialTimeout      = flag.Duration("timeout", defaultDialTimeout, "How long to wait for the connection to be accepted")
+	idleTimeout      = flag.Duration("idle-timeout", defaultIdleTimeout, "Maximum time that a connection is idle. If no messages are received within this timeframe, connection will be terminated")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	outputsDir       = flag.String("output-dir", "", "If set defines a directory to emit output/errors from commands. Files will be generated based on target as destination/0 destination/0.error, etc.")
 	justification    = flag.String("justification", "", "If non-empty will add the key '"+rpcauth.ReqJustKey+"' to the outgoing context Metadata to be passed along to the server for possible validation and logging.")
@@ -169,7 +171,8 @@ func main() {
 		Outputs:      *outputsFlag.Target,
 		OutputsDir:   *outputsDir,
 		CredSource:   *credSource,
-		Timeout:      *timeout,
+		DialTimeout:  *dialTimeout,
+		IdleTimeout:  *idleTimeout,
 		ClientPolicy: clientPolicy,
 		PrefixOutput: *prefixHeader,
 		BatchSize:    *batchSize,

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -70,7 +70,7 @@ var (
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
-	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted")
+	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted. Timeout specified in --targets or --proxy will take precedence")
 	idleTimeout      = flag.Duration("idle-timeout", defaultIdleTimeout, "Maximum time that a connection is idle. If no messages are received within this timeframe, connection will be terminated")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	outputsDir       = flag.String("output-dir", "", "If set defines a directory to emit output/errors from commands. Files will be generated based on target as destination/0 destination/0.error, etc.")
@@ -152,11 +152,11 @@ func main() {
 
 	// Validate and add the default proxy port (if needed).
 	if *proxyAddr != "" {
-		*proxyAddr = cmdUtil.ValidateAndAddPortAndTimeout(*proxyAddr, defaultProxyPort, dialTimeout.String())
+		*proxyAddr = cmdUtil.ValidateAndAddPortAndTimeout(*proxyAddr, defaultProxyPort, *dialTimeout)
 	}
 	// Validate and add the default target port (if needed) for each target.
 	for i, t := range *targetsFlag.Target {
-		(*targetsFlag.Target)[i] = cmdUtil.ValidateAndAddPortAndTimeout(t, defaultTargetPort, dialTimeout.String())
+		(*targetsFlag.Target)[i] = cmdUtil.ValidateAndAddPortAndTimeout(t, defaultTargetPort, *dialTimeout)
 	}
 
 	clientPolicy := cmdUtil.ChoosePolicy(logr.Discard(), "", *clientPolicyFlag, *clientPolicyFile)

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -70,6 +70,8 @@ var (
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
+	// Deprecated: --timeout flag is deprecated. Use --idle-timeout or --dial-timeout instead
+	timeout          = flag.Duration("timeout", defaultDialTimeout, "DEPRECATED. Please use --idle-timeout or --dial-timeout instead")
 	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted. Timeout specified in --targets or --proxy will take precedence")
 	idleTimeout      = flag.Duration("idle-timeout", defaultIdleTimeout, "Maximum time that a connection is idle. If no messages are received within this timeframe, connection will be terminated")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -120,7 +120,18 @@ func init() {
 	subcommands.ImportantFlag("v")
 }
 
+func isFlagPassed(name string) bool {
+	result := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			result = true
+		}
+	})
+	return result
+}
+
 func main() {
+
 	// If this is blank it'll remain blank which is fine
 	// as that means just talk to --targets[0] instead.
 	// If the flag itself was set that will override.
@@ -130,6 +141,9 @@ func main() {
 		"targets": func(string) []string { return []string{"localhost"} },
 	})
 	flag.Parse()
+	if isFlagPassed("timeout") {
+		log.Fatalf("DEPRECATED: --timeout flag is deprecated. Please use --dial-timeout or --idle-timeout instead. Run `sanssh help` for details")
+	}
 
 	// If we're given a --targets-file read it in and stuff into targetsFlag
 	// so it can be processed below as if it was set that way.

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -70,7 +70,7 @@ var (
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
-	dialTimeout      = flag.Duration("timeout", defaultDialTimeout, "How long to wait for the connection to be accepted")
+	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted")
 	idleTimeout      = flag.Duration("idle-timeout", defaultIdleTimeout, "Maximum time that a connection is idle. If no messages are received within this timeframe, connection will be terminated")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	outputsDir       = flag.String("output-dir", "", "If set defines a directory to emit output/errors from commands. Files will be generated based on target as destination/0 destination/0.error, etc.")
@@ -152,11 +152,11 @@ func main() {
 
 	// Validate and add the default proxy port (if needed).
 	if *proxyAddr != "" {
-		*proxyAddr = cmdUtil.ValidateAndAddPort(*proxyAddr, defaultProxyPort)
+		*proxyAddr = cmdUtil.ValidateAndAddPortAndTimeout(*proxyAddr, defaultProxyPort, dialTimeout.String())
 	}
 	// Validate and add the default target port (if needed) for each target.
 	for i, t := range *targetsFlag.Target {
-		(*targetsFlag.Target)[i] = cmdUtil.ValidateAndAddPort(t, defaultTargetPort)
+		(*targetsFlag.Target)[i] = cmdUtil.ValidateAndAddPortAndTimeout(t, defaultTargetPort, dialTimeout.String())
 	}
 
 	clientPolicy := cmdUtil.ChoosePolicy(logr.Discard(), "", *clientPolicyFlag, *clientPolicyFile)
@@ -171,7 +171,6 @@ func main() {
 		Outputs:      *outputsFlag.Target,
 		OutputsDir:   *outputsDir,
 		CredSource:   *credSource,
-		DialTimeout:  *dialTimeout,
 		IdleTimeout:  *idleTimeout,
 		ClientPolicy: clientPolicy,
 		PrefixOutput: *prefixHeader,

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -62,7 +62,7 @@ const (
 )
 
 var (
-	defaultDialTimeout = 30 * time.Second
+	defaultDialTimeout = 10 * time.Second
 	defaultIdleTimeout = 15 * time.Minute
 
 	proxyAddr = flag.String("proxy", "", fmt.Sprintf(

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -71,7 +71,7 @@ var (
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
 	// Deprecated: --timeout flag is deprecated. Use --idle-timeout or --dial-timeout instead
-	timeout          = flag.Duration("timeout", defaultDialTimeout, "DEPRECATED. Please use --idle-timeout or --dial-timeout instead")
+	_                = flag.Duration("timeout", defaultDialTimeout, "DEPRECATED. Please use --idle-timeout or --dial-timeout instead")
 	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted. Timeout specified in --targets or --proxy will take precedence")
 	idleTimeout      = flag.Duration("idle-timeout", defaultIdleTimeout, "Maximum time that a connection is idle. If no messages are received within this timeframe, connection will be terminated")
 	credSource       = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -85,7 +85,7 @@ func ValidateAndAddPortAndTimeout(s string, port int, dialTimeout time.Duration)
 		if _, err := time.ParseDuration(timeout); err != nil {
 			logFatalf("Invalid timeout %s - should be of the form time.Duration", timeout)
 		}
-	} else { // no timeout, let's validate dialTimeout and add it
+	} else { // no timeout, let's add dialTimeout
 		new = fmt.Sprintf("%s;%s", new, dialTimeout.String())
 	}
 	return new

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -99,3 +99,12 @@ func ValidateAndAddPortAndTimeout(s string, port int, dialTimeout time.Duration)
 	}
 	return new
 }
+
+func StripTimeout(s string) string {
+	p := strings.Split(s, ";")
+	if len(p) == 0 || len(p) > 2 {
+		logFatalf("Invalid address %q - should be of the form host[:port][;<duration>]", s)
+	}
+
+	return p[0]
+}

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -60,10 +60,10 @@ func hasPort(s string) bool {
 	return strings.LastIndex(s, "]") < strings.LastIndex(s, ":")
 }
 
-// ValidateAndAddPort will take a given target address and optionally add a default port
+// ValidateAndAddPortAndTimeout will take a given target address and optionally add a default port and timeout
 // onto it if a port is missing. This will also take in account optional dial timeout
 // suffix and make sure the returned value has that if it exists.
-func ValidateAndAddPort(s string, port int) string {
+func ValidateAndAddPortAndTimeout(s string, port int, timeout string) string {
 	// See if there's a duration appended and pull it off
 	p := strings.Split(s, ";")
 	if len(p) == 0 || len(p) > 2 || p[0] == "" {

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -64,6 +64,13 @@ func hasPort(s string) bool {
 // swappable for testing
 var logFatalf = log.Fatalf
 
+// ValidateAndAddPort will take a given target address and optionally add a default port
+// onto it if a port is missing. This will also take in account optional dial timeout
+// suffix and make sure the returned value has that if it exists.
+func ValidateAndAddPort(s string, port int) string {
+	return ValidateAndAddPortAndTimeout(s, port, 0)
+}
+
 // ValidateAndAddPortAndTimeout will take a given target address and optionally add a default port and timeout
 // onto it if a port or a timeout is missing.
 func ValidateAndAddPortAndTimeout(s string, port int, dialTimeout time.Duration) string {
@@ -86,7 +93,9 @@ func ValidateAndAddPortAndTimeout(s string, port int, dialTimeout time.Duration)
 			logFatalf("Invalid timeout %s - should be of the form time.Duration", timeout)
 		}
 	} else { // no timeout, let's add dialTimeout
-		new = fmt.Sprintf("%s;%s", new, dialTimeout.String())
+		if dialTimeout != 0 {
+			new = fmt.Sprintf("%s;%s", new, dialTimeout.String())
+		}
 	}
 	return new
 }

--- a/cmd/util/util_test.go
+++ b/cmd/util/util_test.go
@@ -78,6 +78,14 @@ func TestValidateAndAddPortAndTimeout(t *testing.T) {
 			expectedResult: "",
 			expectFatal:    true,
 		},
+		{
+			name:           "zero timeout shouldn't be added",
+			s:              "localhost",
+			port:           2345,
+			dialTimeout:    0,
+			expectedResult: "localhost:2345",
+			expectFatal:    false,
+		},
 	}
 	for _, tc := range tests {
 		fatalCalled := false

--- a/cmd/util/util_test.go
+++ b/cmd/util/util_test.go
@@ -1,0 +1,95 @@
+package util
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/Snowflake-Labs/sansshell/testing/testutil"
+)
+
+func TestValidateAndAddPortAndTimeout(t *testing.T) {
+	defer func() { logFatalf = log.Fatalf }() // replace the original func after this test
+	tests := []struct {
+		name           string
+		s              string
+		port           int
+		dialTimeout    time.Duration
+		expectFatal    bool
+		expectedResult string
+	}{
+		{
+			name:           "port and timeout exists, shouldn't change anything",
+			s:              "localhost:9999;12s",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "localhost:9999;12s",
+		},
+		{
+			name:           "port doesn't exists, should be added",
+			s:              "localhost;12s",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "localhost:2345;12s",
+		},
+		{
+			name:           "timeout doesn't exists, should be added",
+			s:              "localhost:9999",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "localhost:9999;30s",
+		},
+		{
+			name:           "port and timeout don't exist, both should be added",
+			s:              "localhost",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "localhost:2345;30s",
+		},
+		{
+			name:           "invalid timeout without port, should fatal",
+			s:              "localhost;3030",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "",
+			expectFatal:    true,
+		},
+		{
+			name:           "invalid timeout with port, should fatal",
+			s:              "localhost:9999;3030",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "",
+			expectFatal:    true,
+		},
+		{
+			name:           "empty string, should fatal",
+			s:              "",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "",
+			expectFatal:    true,
+		},
+		{
+			name:           "semicolon only, should fatal",
+			s:              ";",
+			port:           2345,
+			dialTimeout:    time.Second * 30,
+			expectedResult: "",
+			expectFatal:    true,
+		},
+	}
+	for _, tc := range tests {
+		fatalCalled := false
+		logFatalf = func(format string, v ...any) {
+			fatalCalled = true
+		}
+		result := ValidateAndAddPortAndTimeout(tc.s, tc.port, tc.dialTimeout)
+		if tc.expectFatal {
+			// if expect fatal, no need to validate result
+			testutil.DiffErr(tc.name, fatalCalled, tc.expectFatal, t)
+		} else {
+			testutil.DiffErr(tc.name, result, tc.expectedResult, t)
+		}
+	}
+}

--- a/proxy/proxy/proxy.go
+++ b/proxy/proxy/proxy.go
@@ -683,6 +683,7 @@ func (p *Conn) Close() error {
 	return p.cc.Close()
 }
 
+// targets are in the form of host[:port][;<duration>]
 func parseTargets(targets []string) ([]string, []*time.Duration, error) {
 	var hostport []string
 	var timeouts []*time.Duration

--- a/proxy/proxy/proxy.go
+++ b/proxy/proxy/proxy.go
@@ -268,32 +268,6 @@ func (p *proxyStream) SendMsg(args interface{}) error {
 	return p.send(m)
 }
 
-func RecvWithTimeout(resp proxypb.Proxy_ProxyClient, timeout time.Duration) (*proxypb.ProxyReply, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
-	defer cancel()
-	respCh := make(chan *proxypb.ProxyReply, 1)
-	errCh := make(chan error, 1)
-	go func() {
-		resp, err := resp.Recv()
-		if err != nil {
-			errCh <- err
-		}
-		respCh <- resp
-	}()
-	var rs *proxypb.ProxyReply
-	var errRecv error
-	select {
-	case <-ctx.Done():
-		errRecv = fmt.Errorf("connection closed due to no activity after %s: %v", timeout, ctx.Err())
-	case err := <-errCh:
-		errRecv = fmt.Errorf("recv error: %v", err)
-	case r := <-respCh:
-		rs = r
-	}
-
-	return rs, errRecv
-}
-
 // see grpc.ClientStream
 func (p *proxyStream) RecvMsg(m interface{}) error {
 	// Up front check for nothing left since we closed all streams.
@@ -340,13 +314,7 @@ func (p *proxyStream) RecvMsg(m interface{}) error {
 		p.sentErrors = true
 	}
 
-	var err error
-	var resp *proxypb.ProxyReply
-	if p.idleTimeout != nil {
-		resp, err = RecvWithTimeout(p.stream, *p.idleTimeout)
-	} else {
-		resp, err = p.stream.Recv()
-	}
+	resp, err := p.stream.Recv()
 	// If it's io.EOF the upper level code will handle that.
 	if err != nil {
 		return err
@@ -607,13 +575,7 @@ func (p *Conn) InvokeOneMany(ctx context.Context, method string, args interface{
 		// Now do receives until we get all the responses or closes for each stream ID.
 	processing:
 		for {
-			var err error
-			var resp *proxypb.ProxyReply
-			if p.IdleTimeout != nil {
-				resp, err = RecvWithTimeout(s.stream, *p.IdleTimeout)
-			} else {
-				resp, err = s.stream.Recv()
-			}
+			resp, err := s.stream.Recv()
 			if err == io.EOF {
 				break
 			}

--- a/proxy/proxy/proxy.go
+++ b/proxy/proxy/proxy.go
@@ -50,10 +50,6 @@ type Conn struct {
 	// Possible dial dialTimeouts for each target
 	dialTimeouts []*time.Duration
 
-	// IdleTimeout is the time limit for an idle connection.
-	// If no messages are received within this timeframe, connection will be closed.
-	IdleTimeout *time.Duration
-
 	// The RPC connection to the proxy.
 	cc *grpc.ClientConn
 
@@ -92,8 +88,6 @@ type proxyStream struct {
 	errors     []*Ret
 	sentErrors bool
 	sendClosed bool
-	// idleTimeout is the duration to wait for action to complete
-	idleTimeout *time.Duration
 }
 
 // Invoke - see grpc.ClientConnInterface
@@ -162,11 +156,10 @@ func (p *Conn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method stri
 	}
 
 	s := &proxyStream{
-		method:      method,
-		stream:      stream,
-		ids:         streamIds,
-		errors:      errors,
-		idleTimeout: p.IdleTimeout,
+		method: method,
+		stream: stream,
+		ids:    streamIds,
+		errors: errors,
 	}
 
 	return s, nil

--- a/proxy/proxy/proxy.go
+++ b/proxy/proxy/proxy.go
@@ -340,7 +340,13 @@ func (p *proxyStream) RecvMsg(m interface{}) error {
 		p.sentErrors = true
 	}
 
-	resp, err := RecvWithTimeout(p.stream, *p.idleTimeout)
+	var err error
+	var resp *proxypb.ProxyReply
+	if p.idleTimeout != nil {
+		resp, err = RecvWithTimeout(p.stream, *p.idleTimeout)
+	} else {
+		resp, err = p.stream.Recv()
+	}
 	// If it's io.EOF the upper level code will handle that.
 	if err != nil {
 		return err
@@ -601,7 +607,13 @@ func (p *Conn) InvokeOneMany(ctx context.Context, method string, args interface{
 		// Now do receives until we get all the responses or closes for each stream ID.
 	processing:
 		for {
-			resp, err := RecvWithTimeout(s.stream, *p.IdleTimeout)
+			var err error
+			var resp *proxypb.ProxyReply
+			if p.IdleTimeout != nil {
+				resp, err = RecvWithTimeout(s.stream, *p.IdleTimeout)
+			} else {
+				resp, err = s.stream.Recv()
+			}
 			if err == io.EOF {
 				break
 			}

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -122,6 +122,7 @@ func (p *runCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface
 
 	c := pb.NewExecClientProxy(state.Conn)
 	req := &pb.ExecRequest{Command: f.Args()[0], Args: f.Args()[1:]}
+
 	if p.streaming {
 		resp, err := c.StreamingRunOneMany(ctx, req)
 		if err != nil {
@@ -131,6 +132,7 @@ func (p *runCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface
 			}
 			return subcommands.ExitFailure
 		}
+
 		for {
 			rs, err := resp.Recv()
 			if err != nil {

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -115,8 +115,7 @@ func (p *runCmd) printCommandOutput(state *util.ExecuteState, idx int, resp *pb.
 }
 
 func RecvWithTimeout(ctx context.Context, resp pb.Exec_StreamingRunClientProxy) ([]*pb.StreamingRunManyResponse, error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	respCh := make(chan []*pb.StreamingRunManyResponse, 1)
 	errCh := make(chan error, 1)

--- a/services/exec/client/client.go
+++ b/services/exec/client/client.go
@@ -159,7 +159,7 @@ func (p *runCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface
 			return subcommands.ExitFailure
 		}
 		for {
-			rs, errRecv := RecvWithTimeout(ctx, resp)
+			rs, errRecv := resp.Recv()
 			if errRecv != nil {
 				if errRecv == io.EOF {
 					return p.returnCode

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -16,7 +16,6 @@
 # under the License.
 
 set -o nounset
-
 # check_status takes 3 args:
 #
 # A code to compare against
@@ -606,7 +605,7 @@ check_status $? /dev/null cant find proxy version in logs
 
 echo "Checking prefix option functions"
 ${SANSSH_PROXY} -h ${SINGLE_TARGET} file read /etc/hosts >&${LOGS}/prefix-test
-prefix_lines=$(cat ${LOGS}/prefix-test | grep -E -c -e '^0-localhost:50042: ')
+prefix_lines=$(cat ${LOGS}/prefix-test | grep -E -c -e '^0-localhost:50042;10s')
 total_lines=$(wc -l </etc/hosts)
 if [ "${prefix_lines}" != "${total_lines}" ]; then
   check_status 1 "line count different for prefix check - prefix log ${LOGS}/prefix-test ${prefix_lines} vs /etc/hosts ${total_lines}"
@@ -628,16 +627,16 @@ fi
 mkdir -p ${LOGS}/exec-testdir
 ${SANSSH_PROXY} ${MULTI_TARGETS} --output-dir=${LOGS}/exec-testdir exec run /bin/sh -c "echo foo >&2"
 check_status $? /dev/null exec failed emitting to stderr
-if [ ! -f ${LOGS}/exec-testdir/0-localhost:50042 ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042 ]; then
+if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042;10s" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042;10s" ]; then
   check_status 1 /dev/null "exec output files do not exist"
 fi
-if [ -s ${LOGS}/exec-testdir/0-localhost:50042 ] || [ -s ${LOGS}/exec-testdir/1-localhost:50042 ]; then
+if [ -s "${LOGS}/exec-testdir/0-localhost:50042;10s" ] || [ -s "${LOGS}/exec-testdir/1-localhost:50042;10s" ]; then
   check_status 1 /dev/null "exec output appeared in normal output files in ${LOGS}/exec-testdir"
 fi
-if [ ! -f ${LOGS}/exec-testdir/0-localhost:50042.error ] || [ ! -f ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
+if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042;10s.error" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042;10s.error" ]; then
   check_status 1 /dev/null "exec error output files do not exist"
 fi
-if [ ! -s ${LOGS}/exec-testdir/0-localhost:50042.error ] || [ ! -s ${LOGS}/exec-testdir/1-localhost:50042.error ]; then
+if [ ! -s "${LOGS}/exec-testdir/0-localhost:50042;10s.error" ] || [ ! -s "${LOGS}/exec-testdir/1-localhost:50042;10s.error" ]; then
   check_status 1 /dev/null "exec error output did not appear in ${LOGS}/exec-testdir error files"
 fi
 

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -512,7 +512,7 @@ else
   echo "Skipping remote cloud setup on Github"
 fi
 
-SANSSH_NOPROXY_NO_JUSTIFY="./bin/sanssh --root-ca=./auth/mtls/testdata/root.pem --client-cert=./auth/mtls/testdata/client.pem --client-key=./auth/mtls/testdata/client.key --timeout=120s"
+SANSSH_NOPROXY_NO_JUSTIFY="./bin/sanssh --root-ca=./auth/mtls/testdata/root.pem --client-cert=./auth/mtls/testdata/client.pem --client-key=./auth/mtls/testdata/client.key --idle-timeout=120s"
 SANSSH_NOPROXY="${SANSSH_NOPROXY_NO_JUSTIFY} --justification=yes"
 SANSSH_PROXY_NOPORT="${SANSSH_NOPROXY} --proxy=localhost"
 SANSSH_PROXY="${SANSSH_PROXY_NOPORT}:50043 --batch-size=1"
@@ -560,7 +560,7 @@ allow {
   input.peer.cert.subject.organization[i] = "foo"
 }
 EOF
-${SANSSH_PROXY} ${SINGLE_TARGET} --v=1 --client-policy-file=${LOGS}/client-policy.rego --timeout=10s healthcheck validate
+${SANSSH_PROXY} ${SINGLE_TARGET} --v=1 --client-policy-file=${LOGS}/client-policy.rego --idle-timeout=10s healthcheck validate
 if [ $? != 1 ]; then
   check_status 1 /dev/null policy check did not fail
 fi
@@ -979,7 +979,7 @@ check_mv
 echo "parallel work with some bad targets and various timeouts"
 mkdir -p "${LOGS}/parallel"
 start=$(date +%s)
-if ${SANSSH_NOPROXY} --proxy="localhost;2s" --timeout=10s --output-dir="${LOGS}/parallel" --targets="localhost:50042;3s,1.1.1.1;4s,0.0.0.1;5s,localhost;6s" healthcheck validate; then
+if ${SANSSH_NOPROXY} --proxy="localhost;2s" --idle-timeout=10s --output-dir="${LOGS}/parallel" --targets="localhost:50042;3s,1.1.1.1;4s,0.0.0.1;5s,localhost;6s" healthcheck validate; then
   check_status 1 /dev/null healthcheck did not error out
 fi
 end=$(date +%s)

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -605,7 +605,7 @@ check_status $? /dev/null cant find proxy version in logs
 
 echo "Checking prefix option functions"
 ${SANSSH_PROXY} -h ${SINGLE_TARGET} file read /etc/hosts >&${LOGS}/prefix-test
-prefix_lines=$(cat ${LOGS}/prefix-test | grep -E -c -e '^0-localhost:50042;10s')
+prefix_lines=$(cat ${LOGS}/prefix-test | grep -E -c -e '^0-localhost:50042')
 total_lines=$(wc -l </etc/hosts)
 if [ "${prefix_lines}" != "${total_lines}" ]; then
   check_status 1 "line count different for prefix check - prefix log ${LOGS}/prefix-test ${prefix_lines} vs /etc/hosts ${total_lines}"
@@ -627,16 +627,16 @@ fi
 mkdir -p ${LOGS}/exec-testdir
 ${SANSSH_PROXY} ${MULTI_TARGETS} --output-dir=${LOGS}/exec-testdir exec run /bin/sh -c "echo foo >&2"
 check_status $? /dev/null exec failed emitting to stderr
-if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042;10s" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042;10s" ]; then
+if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042" ]; then
   check_status 1 /dev/null "exec output files do not exist"
 fi
-if [ -s "${LOGS}/exec-testdir/0-localhost:50042;10s" ] || [ -s "${LOGS}/exec-testdir/1-localhost:50042;10s" ]; then
+if [ -s "${LOGS}/exec-testdir/0-localhost:50042" ] || [ -s "${LOGS}/exec-testdir/1-localhost:50042" ]; then
   check_status 1 /dev/null "exec output appeared in normal output files in ${LOGS}/exec-testdir"
 fi
-if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042;10s.error" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042;10s.error" ]; then
+if [ ! -f "${LOGS}/exec-testdir/0-localhost:50042.error" ] || [ ! -f "${LOGS}/exec-testdir/1-localhost:50042.error" ]; then
   check_status 1 /dev/null "exec error output files do not exist"
 fi
-if [ ! -s "${LOGS}/exec-testdir/0-localhost:50042;10s.error" ] || [ ! -s "${LOGS}/exec-testdir/1-localhost:50042;10s.error" ]; then
+if [ ! -s "${LOGS}/exec-testdir/0-localhost:50042.error" ] || [ ! -s "${LOGS}/exec-testdir/1-localhost:50042.error" ]; then
   check_status 1 /dev/null "exec error output did not appear in ${LOGS}/exec-testdir error files"
 fi
 


### PR DESCRIPTION
This PR changes sanssh timeout behaviors. 
1. Dial Timeout
  * Currently dial timeout can only be specified in the targets or proxy address, such as `--proxy=localhost:50043;5s`. If it's not set, we'll use the default grpc dial timeout which is 20s.
  * I'm adding a new flag `--dial-timeout`, default to 10s. I'm hoping that this is easier to use compared to specifying timeout in addresses. 
  This will be the dial timeout used if the target or proxy address doesn't contain a timeout. In other words, timeout specified in the target or proxy address takes precedence over this flag.
  
2. Idle Timeout
  * Currently, `--timeout` flag (default to 30s) is used to define the duration to wait for the command to complete. The timeout counter doesn't reset even if there are responses from the server, which is problematic for streaming RPCs because we don't want to terminate the command while server is still progressing.
  * I'm renaming this to `--idle-timeout`, default to 15m. Now the timeout will reset when there's a response from the server. It will timeout when there's no new responses for the duration specified in the flag. This is done by adding gRPC interceptors that add deadline to every Send or Recv call. 

Rationale for default timeout values (10s dial timeout, and 15m idle timeout): we want to fail fast during initial connection, but it's okay to wait a bit longer for a target that's initially responsive.