### PR TITLE
add httpoverproxy get example to command usage

### DIFF
--- a/services/httpoverrpc/client/client.go
+++ b/services/httpoverrpc/client/client.go
@@ -223,9 +223,14 @@ func (*getCmd) Name() string     { return "get" }
 func (*getCmd) Synopsis() string { return "Makes a HTTP call to a port on a remote host" }
 func (*getCmd) Usage() string {
 	return `get [-method METHOD] [-header Header...] [-body body] [-protocol Protocol] [-hostname Hostname] remoteport request_uri:
-    Make a HTTP request to a specified port on the remote host.
+	Make a HTTP request to a specified port on the remote host.
 
-	Note: if we set the domain name other than localhost for flag --hostname, and want to use snsshell proxy action to proxy requests
+	Example: 
+	httpoverrpc get --hostname localhost --protocol https 9090 /hello (the prefix / in request_uri is always needed, 
+	even there is nothing to put)
+
+	Note: 
+	If we set the domain name other than localhost for flag --hostname, and want to use snsshell proxy action to proxy requests
 	don't forget to add --allow-any-host for proxy action
 `
 }

--- a/services/httpoverrpc/client/client.go
+++ b/services/httpoverrpc/client/client.go
@@ -226,7 +226,7 @@ func (*getCmd) Usage() string {
   Make a HTTP request to a specified port on the remote host.
 
   Example: 
-  httpoverrpc get --hostname localhost --protocol https 9090 /hello 
+  httpoverrpc get --hostname 10.1.23.4 --protocol https 9090 /hello 
 
   Note: 
   1. The prefix / in request_uri is always needed, even there is nothing to put

--- a/services/httpoverrpc/client/client.go
+++ b/services/httpoverrpc/client/client.go
@@ -223,15 +223,15 @@ func (*getCmd) Name() string     { return "get" }
 func (*getCmd) Synopsis() string { return "Makes a HTTP call to a port on a remote host" }
 func (*getCmd) Usage() string {
 	return `get [-method METHOD] [-header Header...] [-body body] [-protocol Protocol] [-hostname Hostname] remoteport request_uri:
-	Make a HTTP request to a specified port on the remote host.
+  Make a HTTP request to a specified port on the remote host.
 
-	Example: 
-	httpoverrpc get --hostname localhost --protocol https 9090 /hello (the prefix / in request_uri is always needed, 
-	even there is nothing to put)
+  Example: 
+  httpoverrpc get --hostname localhost --protocol https 9090 /hello 
 
-	Note: 
-	If we set the domain name other than localhost for flag --hostname, and want to use snsshell proxy action to proxy requests
-	don't forget to add --allow-any-host for proxy action
+  Note: 
+  1. The prefix / in request_uri is always needed, even there is nothing to put
+  2. If we use --hostname to send requests to a specified host instead of the default localhost, and want to use snsshell proxy action 
+  to proxy requests, don't forget to add --allow-any-host for proxy action
 `
 }
 


### PR DESCRIPTION
# Description
The argument request_uri in httpoverproxy get action may be a bit confusing for users, so we add an example in usage and remind users to always add prefix `/` in uri