### PR TITLE
Fix: change the rpc method name from Localhost to Host in OPA policy …

### DIFF
--- a/cmd/proxy-server/default-policy.rego
+++ b/cmd/proxy-server/default-policy.rego
@@ -22,7 +22,7 @@ allow {
 
 # Allow proxying HTTP requests
 allow {
-	input.method = "/HTTPOverRPC.HTTPOverRPC/Localhost"
+	input.method = "/HTTPOverRPC.HTTPOverRPC/Host"
 }
 
 # Allow anyone to call healthcheck on any host

--- a/cmd/sansshell-server/default-policy.rego
+++ b/cmd/sansshell-server/default-policy.rego
@@ -16,7 +16,7 @@ allow {
 }
 
 allow {
-	input.method = "/HTTPOverRPC.HTTPOverRPC/Localhost"
+	input.method = "/HTTPOverRPC.HTTPOverRPC/Host"
 }
 
 allow {


### PR DESCRIPTION
## Description
In PR https://github.com/Snowflake-Labs/sansshell/pull/290, we changed the rpc method from "/HTTPOverRPC.HTTPOverRPC/Localhost" to "/HTTPOverRPC.HTTPOverRPC/Host", so here all old rpc methods should be updated