### PR TITLE
Fix http client requestURI

### DIFF
--- a/services/httpoverrpc/client/utils.go
+++ b/services/httpoverrpc/client/utils.go
@@ -125,7 +125,7 @@ func (c *HTTPTransporter) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	reqPb := &pb.HostHTTPRequest{
 		Request: &pb.HTTPRequest{
-			RequestUri: req.URL.Path,
+			RequestUri: req.URL.RequestURI(),
 			Method:     req.Method,
 			Headers:    httpHeaderToPbHeader(&req.Header),
 			Body:       body,


### PR DESCRIPTION
`req.URL.Path` doesn't include query, so I'm changing this to `req.URL.RequestURI()` which returns the encoded `path?query`