### PR TITLE
Add a proto incompatibility check

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Lint
 on:
   pull_request:
 permissions:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 jobs:
   golangci:
-    name: lint
+    name: golangci lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,3 +17,12 @@ jobs:
         with:
           version: latest
           args: --timeout=5m
+  buf-breaking:
+    name: incompatible proto changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          against:  "https://github.com/Snowflake-Labs/sansshell.git#branch=main" 


### PR DESCRIPTION
We've had a couple recent cases (https://github.com/Snowflake-Labs/sansshell/pull/327, https://github.com/Snowflake-Labs/sansshell/pull/281) where we've accidentally made backwards incompatible changes to our protobufs. This seems preventable by adding in automated checks.
 
I'm using https://github.com/bufbuild/buf-breaking-action and checking against main. I considered adding buf linting as well, but the linting detects tons of preexisting stylistic choices so it didn't seem worth doing so.