### PR TITLE
Always logs authz policy eval result

### DIFF
--- a/auth/opa/rpcauth/rpcauth.go
+++ b/auth/opa/rpcauth/rpcauth.go
@@ -133,7 +133,7 @@ func (g *Authorizer) Eval(ctx context.Context, input *RPCAuthInput) error {
 			logger.V(1).Error(err, "failed to get hints for authz policy denial", "error", err)
 		}
 	}
-	logger.V(1).Info("authz policy evaluation result", "authorizationResult", result, "input", input, "denialHints", hints)
+	logger.Info("authz policy evaluation result", "authorizationResult", result, "input", input, "denialHints", hints)
 	if !result {
 		errRegister := recorder.Counter(ctx, authzDeniedPolicyCounter, 1, attribute.String("method", input.Method))
 		if errRegister != nil {


### PR DESCRIPTION
Setting authz policy eval result log level to `0` so that it always gets logged.
Currently https://github.com/Snowflake-Labs/sansshell/blob/3a057e18ed4b0ac8a33a6af10db5b34c6c936469/telemetry/telemetry.go#L180 is at level 0, so it makes more sense to also log policy eval result.

Testing

```
rpcauth.go:138: sanshell-server: "level"=0 "msg"="authz policy evaluation result" "method"="/HealthCheck.HealthCheck/Ok" "peer"={"net":{"network":"tcp","address":"127.0.0.1","port":"54933"},"cert":...
```