### PR TITLE
Change dependabot to weekly and group otel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"


### PR DESCRIPTION
The dependabot PRs feel a bit too frequent. Otel changes in particular have a habit of spitting out 4-5 PRs at once that update a bunch of related dependencies to the same version.

Weekly frequency and grouped otel should make things less noisy without reducing our rate of updating much.