### PR TITLE
Remove the special-case for the final batch when batching calls

### DIFF
--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -402,6 +402,11 @@ func Run(ctx context.Context, rs RunState) {
 		state.Conn = conn
 		state.Out = output[start:end]
 		state.Err = errors[start:end]
+		if len(rs.Targets) == 0 {
+			// Special case - if we're talking directly to the proxy, we have an output of size 1
+			state.Out = output[:1]
+			state.Err = errors[:1]
+		}
 		if subcommands.Execute(ctx, state) != subcommands.ExitSuccess {
 			exitCode = subcommands.ExitFailure
 		}

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -383,12 +383,12 @@ func Run(ctx context.Context, rs RunState) {
 	output := state.Out
 	errors := state.Err
 
-	batchCnt := 0
+	batchCnt := 1
 	if len(rs.Targets) > 0 {
-		batchCnt = len(rs.Targets) / rs.BatchSize
+		// How many batches? Integer math truncates so we have to do one more for remainder.
+		batchCnt = (len(rs.Targets)-1)/rs.BatchSize + 1
 	}
-	// How many batches? Integer math truncates so we have to do one more for remainder.
-	for i := 0; i < batchCnt+1; i++ {
+	for i := 0; i < batchCnt; i++ {
 		start, end := i*rs.BatchSize, rs.BatchSize*(i+1)
 		if end > len(rs.Targets) {
 			end = len(rs.Targets)


### PR DESCRIPTION
There's some repetitive logic between these calls and I'm going to add slightly more as part of implementing MPA. We can remove the logic duplication by instead adding a conditional to shorten the size of the final batch.