### PR TITLE
Use a 16MB recv buffer in proxy/sanssh instead of the default 4MB.

### DIFF
--- a/cmd/proxy-server/server/server.go
+++ b/cmd/proxy-server/server/server.go
@@ -420,6 +420,8 @@ func Run(ctx context.Context, opts ...Option) {
 		grpc.WithTransportCredentials(clientCreds),
 		grpc.WithChainUnaryInterceptor(unaryClient...),
 		grpc.WithChainStreamInterceptor(streamClient...),
+		// Use 16MB instead of the default 4MB to allow larger responses
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(16 * 1024 * 1024)),
 	}
 	targetDialer := server.NewDialer(dialOpts...)
 

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -313,6 +313,8 @@ func Run(ctx context.Context, rs RunState) {
 	// We may need an option for doing client OPA checks.
 	ops := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
+		// Use 16MB instead of the default 4MB to allow larger responses
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(16 * 1024 * 1024)),
 	}
 	streamInterceptors := []grpc.StreamClientInterceptor{}
 	unaryInterceptors := []grpc.UnaryClientInterceptor{}


### PR DESCRIPTION
We occasionally hit issues due to the size limitations. Calls like file reads and streaming exec are fine because each individual message is significantly smaller than 4MB, but non-streaming exec and some other unary calls that return large blobs of data can be at risk of hitting the limit. Increasing the limit lets us keep using unary calls instead of dealing with the increased complexity of turning them into streaming calls.

This has a minor risk of increasing memory usage when we would previously fail calls. Given the nature of sansshell, I think that's an acceptable tradeoff.