### PR TITLE
Fix journalctl response output for multiple targets

### DIFF
--- a/services/sysinfo/client/client.go
+++ b/services/sysinfo/client/client.go
@@ -288,7 +288,7 @@ func (p *journalCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 			exit = subcommands.ExitFailure
 			break
 		}
-		for i, r := range resp {
+		for _, r := range resp {
 			if r.Error != nil && r.Error != io.EOF {
 				fmt.Fprintf(state.Err[r.Index], "Target %s (%d) returned error - %v\n", r.Target, r.Index, r.Error)
 				targetsDone[r.Index] = true
@@ -313,7 +313,7 @@ func (p *journalCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 				if journal.Pid != 0 {
 					displayPid = fmt.Sprintf("[%d]", journal.Pid)
 				}
-				fmt.Fprintf(state.Out[i], "[%s]  %s %s%s: %s\n", journal.RealtimeTimestamp.AsTime().Local(), journal.Hostname, journal.SyslogIdentifier, displayPid, journal.Message)
+				fmt.Fprintf(state.Out[r.Index], "[%s]  %s %s%s: %s\n", journal.RealtimeTimestamp.AsTime().Local(), journal.Hostname, journal.SyslogIdentifier, displayPid, journal.Message)
 			case *pb.JournalReply_JournalRaw:
 				journalRaw := t.JournalRaw
 				// Encode the map to JSON
@@ -328,7 +328,7 @@ func (p *journalCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...inter
 				}
 				// Convert the JSON data to a string
 				jsonString := string(jsonData)
-				fmt.Fprintf(state.Out[i], "%s\n", jsonString)
+				fmt.Fprintf(state.Out[r.Index], "%s\n", jsonString)
 			}
 		}
 	}


### PR DESCRIPTION
**Problem**
When running journalctl against multiple targets, all results are always piped to the first target's output.
Notice the prefix below
```
./sanssh -h --proxy=localhost --targets=10.211.55.4:9901,10.211.55.4:9902,10.211.55.4:9903 sysinfo journalctl -unit colord -tail 1
0-10.211.55.4:9901: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
0-10.211.55.4:9901: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
0-10.211.55.4:9901: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
```

**Changes**
When processing responses, use response index instead of the for loop index.

Result:
```
 ./sanssh -h --proxy=localhost --targets=10.211.55.4:9901,10.211.55.4:9902,10.211.55.4:9903 sysinfo journalctl -unit colord -tail 1
0-10.211.55.4:9901: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
2-10.211.55.4:9903: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
1-10.211.55.4:9902: [2023-08-16 10:53:06.904706 -0700 PDT]  systemd[1]: Started Manage, Install and Generate Color Profiles.
```