### PR TITLE
Don't fail on missing principal info when proxying identities

### DIFF
--- a/services/mpa/mpahooks/mpahooks.go
+++ b/services/mpa/mpahooks/mpahooks.go
@@ -85,14 +85,15 @@ func ActionMatchesInput(ctx context.Context, action *mpa.Action, input *rpcauth.
 	if err := msg.MarshalFrom(m2); err != nil {
 		return fmt.Errorf("unable to marshal into anyproto: %v", err)
 	}
-	if input.Peer == nil || input.Peer.Principal == nil {
-		return fmt.Errorf("missing peer information")
-	}
 
 	// Prefer using a proxied identity if provided
-	user := input.Peer.Principal.ID
+	var user string
 	if p := proxiedidentity.FromContext(ctx); p != nil {
 		user = p.ID
+	} else if input.Peer != nil && input.Peer.Principal != nil {
+		user = input.Peer.Principal.ID
+	} else {
+		return fmt.Errorf("missing peer information")
 	}
 
 	sentAct := &mpa.Action{

--- a/services/mpa/mpahooks/mpahooks_test.go
+++ b/services/mpa/mpahooks/mpahooks_test.go
@@ -62,12 +62,14 @@ func mustAny(a *anypb.Any, err error) *anypb.Any {
 func TestActionMatchesInput(t *testing.T) {
 	ctx := context.Background()
 	var ctxWithIdentity context.Context
-	proxiedidentity.ServerProxiedIdentityUnaryInterceptor()(
+	if _, err := proxiedidentity.ServerProxiedIdentityUnaryInterceptor()(
 		metadata.NewIncomingContext(ctx, metadata.Pairs("proxied-sansshell-identity", `{"id":"proxied"}`)),
 		nil, nil, func(ctx context.Context, req any) (any, error) {
 			ctxWithIdentity = ctx
 			return nil, nil
-		})
+		}); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tc := range []struct {
 		desc    string


### PR DESCRIPTION
It's valid to have a sansshell setup where communication from a user to the proxy uses an authz hook that populates principal and communication from the proxy to the server doesn't do so. MPA failed for these with "missing peer information" because we checked for principal regardless of whether we were proxying. This change fixes that logic to only fail when both proxied identity and principal are absent..

The testing strategy for adding a proxied identity to a context is a bit odd, but I don't want to widen the public interfaces for proxiedidentity yet.