### PR TITLE
Update logr to v1.4.1

### DIFF
--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -90,10 +90,7 @@ type IntExtension struct {
 func TestAuthzHook(t *testing.T) {
 	ctx := context.Background()
 	var logs string
-	fn := func(p, a string) {
-		logs = a
-	}
-	logger := funcr.New(fn, funcr.Options{Verbosity: 2})
+	logger := funcr.NewJSON(func(obj string) { logs = obj }, funcr.Options{Verbosity: 2})
 	ctx = logr.NewContext(ctx, logger)
 	// This way the tests exercise the logging code.
 	policy, err := opa.NewAuthzPolicy(ctx, policyString)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/euank/go-kmsg-parser/v2 v2.1.0
-	github.com/go-logr/logr v1.3.0
+	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/subcommands v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
-github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=


### PR DESCRIPTION
This wasn't able to get done automatically by dependabot because rpcauth_test.go was looking for a snippet of json and https://github.com/go-logr/logr/commit/44c6ac8097838fd1d648e3eb3b8bd6f15fa61e24 changed `:` to `=` in some places. Switching our test logger to strict json mode makes the existing test pass with both old and new logr versions.