### PR TITLE
Deprecate ServerProxiedIdentity*Interceptor

### DIFF
--- a/auth/opa/proxiedidentity/proxiedidentity_test.go
+++ b/auth/opa/proxiedidentity/proxiedidentity_test.go
@@ -91,7 +91,7 @@ func TestProxyingIdentityOverRPC(t *testing.T) {
 	}{
 		{
 			desc:            "interceptor missing",
-			identityProxied: false,
+			identityProxied: true,
 		},
 		{
 			desc: "passed",

--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -46,7 +46,6 @@ import (
 	"github.com/Snowflake-Labs/sansshell/auth/mtls"
 	mtlsFlags "github.com/Snowflake-Labs/sansshell/auth/mtls/flags"
 	"github.com/Snowflake-Labs/sansshell/auth/opa"
-	"github.com/Snowflake-Labs/sansshell/auth/opa/proxiedidentity"
 	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
 	"github.com/Snowflake-Labs/sansshell/cmd/sansshell-server/server"
 	"github.com/Snowflake-Labs/sansshell/cmd/util"
@@ -172,8 +171,6 @@ func main() {
 		server.WithHostPort(*hostport),
 		server.WithParsedPolicy(parsed),
 		server.WithJustification(*justification),
-		server.WithUnaryInterceptor(proxiedidentity.ServerProxiedIdentityUnaryInterceptor()),
-		server.WithStreamInterceptor(proxiedidentity.ServerProxiedIdentityStreamInterceptor()),
 		server.WithAuthzHook(rpcauth.PeerPrincipalFromCertHook()),
 		server.WithAuthzHook(mpa.ServerMPAAuthzHook()),
 		server.WithRawServerOption(func(s *grpc.Server) { reflection.Register(s) }),

--- a/services/mpa/README.md
+++ b/services/mpa/README.md
@@ -78,14 +78,7 @@ SansShell is built on a principle of "Don't pay for what you don't use". MPA is 
    proxy.WithAuthzHook(mpa.ProxyMPAAuthzHook)
    ```
 
-   You'll also need to set additional interceptors on the server to make proxied identity information available.
-
-   ```go
-   proxiedidentity.ServerProxiedIdentityUnaryInterceptor()
-   proxiedidentity.ServerProxiedIdentityStreamInterceptor()
-   ```
-
-   When setting these interceptors, make sure to update the server's rego policies if it allows callers other than the proxy to make direct calls. For example, the policy below will reject calls if proxied identity information is in the metadata and the caller is something other than a peer with an identity of `"proxy"`.
+   You'll also need to update the server's rego policies to reject requests that unexpectedly set `proxied-sansshell-identity` metadata if it allows callers other than the proxy to make direct calls. If you fail to do so, a direct caller can manipulate the metadata to approve their own request. For example, the policy below will reject calls if proxied identity information is in the metadata and the caller is something other than a peer with an identity of `"proxy"`.
 
    ```rego
    package sansshell.authz


### PR DESCRIPTION
I added these in https://github.com/Snowflake-Labs/sansshell/pull/359 in the original proxiedidentity implementation. In my initial draft I was using them as an additional authorization layer, but I switched to relying on the existing OPA policy authorization layer before submitting.

Now, several months later, I've found another place where I want to use proxied identity data. The interceptors force folks to be intentional about allowing proxying, but in retrospect I think that adds friction without meaningfully helping security. I'd rather remove the need for them.

I'm turning these interceptors into no-ops so that any existing references will continue to work. I've changed proxiedidentity.FromContext to directly work on grpc metadata.