### PR TITLE
FDB Conf Delete: return error if section doesn't exist

### DIFF
--- a/services/fdb/server/conf.go
+++ b/services/fdb/server/conf.go
@@ -100,6 +100,10 @@ func (s *cserver) Delete(_ context.Context, req *pb.DeleteRequest) (*emptypb.Emp
 		return nil, status.Errorf(codes.Internal, "could not load config file %s: %v", req.Location.File, err)
 	}
 
+	if !cfg.HasSection(section) {
+		return nil, status.Errorf(codes.Internal, "section %s does not exist", section)
+	}
+
 	sectionKey := req.Location.Key
 	if sectionKey != "" {
 		cfg.Section(section).DeleteKey(sectionKey)


### PR DESCRIPTION
**Problem**
When deleting a key in a non-existent section, `cfg.Section(section).DeleteKey(sectionKey)` will create an empty section.

Example:

Before
```
[fdbserver.4500]
class        = storage
cache_memory = 1GiB
memory       = 1GiB
knob_max_storage_commit_time = 1m

[fdbserver.4501]
class        = storage
cache_memory = 1GiB
memory       = 1GiB
```
After running `sanssh fdb conf delete fdbserver.9999 new_key`:
```
[fdbserver.4500]
class                        = storage
cache_memory                 = 1GiB
memory                       = 1GiB
knob_max_storage_commit_time = 1m

[fdbserver.4501]
class        = storage
cache_memory = 1GiB
memory       = 1GiB

[fdbserver.9999]
```

**Changes**
* Return an error if the section slated for deletion does not exist