### PR TITLE
Add -u and remove output option for journalctl

### DIFF
--- a/services/sysinfo/client/client.go
+++ b/services/sysinfo/client/client.go
@@ -204,7 +204,7 @@ type journalCmd struct {
 func (*journalCmd) Name() string     { return "journalctl" }
 func (*journalCmd) Synopsis() string { return "Get the log entries stored in journald" }
 func (*journalCmd) Usage() string {
-	return `journalctl [--since|--S=X] [--until|-U=X] [-tail=X] [-u|-unit=X] [-o|--output=X]:
+	return `journalctl [--since|--S=X] [--until|-U=X] [-tail=X] [-u|-unit=X]:
 	Get the log entries stored in journald by systemd-journald.service 
 `
 }
@@ -215,6 +215,7 @@ func (p *journalCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.until, "until", "", "Sets the date (YYYY-MM-DD HH:MM:SS) we want to filter until (the date time is not included)")
 	f.StringVar(&p.until, "U", "", "Sets the date (YYYY-MM-DD HH:MM:SS) we want to filter until")
 	f.StringVar(&p.unit, "unit", "", "Sets systemd unit to filter messages")
+	f.StringVar(&p.unit, "u", "", "Sets systemd unit to filter messages")
 	f.BoolVar(&p.enableJSON, "json", false, "Print the journal entries in JSON format(can work with jq for better visualization)")
 	f.Uint64Var(&p.tail, "tail", 100, "If positive, the latest n records to fetch. By default, fetch latest 100 records. The upper limit is 10000 for now")
 }


### PR DESCRIPTION
# overview

fix the missing option -u as defined below, and remove -output as not implemented
```shell
journalctl [--since|--S=X] [--until|-U=X] [-tail=X] [-u|-unit=X]:
        Get the log entries stored in journald by systemd-journald.service 
```

# testing
```shell
[pchu@XXXX-pchu sansshell]$ go run ./cmd/sanssh --targets=localhost sysinfo journalctl -unit nginx  -tail 2
[2024-05-03 23:17:04.965622 +0000 UTC]  XXXX-pchu nginx[8950]: nginx: [warn] conflicting server name "azureexternalaccount-alias.local" on 0.0.0.0:8084, ignored
[2024-05-03 23:17:04.965648 +0000 UTC]  XXXX-pchu nginx[8950]: nginx: [warn] conflicting server name "gcpexternalaccount_alias.local" on 0.0.0.0:8084, ignored
[pchu@XXXX-pchu sansshell]$ go run ./cmd/sanssh --targets=localhost sysinfo journalctl -u nginx
  -tail 2
[2024-05-03 23:17:04.965622 +0000 UTC]  XXXX-pchu nginx[8950]: nginx: [warn] conflicting server name "azureexternalaccount-alias.local" on 0.0.0.0:8084, ignored
[2024-05-03 23:17:04.965648 +0000 UTC]  XXXX-pchu nginx[8950]: nginx: [warn] conflicting server name "gcpexternalaccount_alias.local" on 0.0.0.0:8084, ignored
```