### PR TITLE
Support reading installed packages split across 3 lines.

### DIFF
--- a/services/packages/server/testdata/yum-installed-old-server-version.textproto
+++ b/services/packages/server/testdata/yum-installed-old-server-version.textproto
@@ -13,3 +13,8 @@ packages : <
   version : "1:1.8.0.292.b10-1.el7_9"
   repo : "@updates"
 >
+packages : <
+  name : "fakepackagesplitacross3lines-1.8.0-openjdk.x86_64"
+  version : "1:1.8.0.292.b10-1.el7_9"
+  repo : "@updates"
+>

--- a/services/packages/server/testdata/yum-installed.out
+++ b/services/packages/server/testdata/yum-installed.out
@@ -5,3 +5,6 @@ adoptopenjdk-11-hotspot.x86_64                                          11.0.11+
 copy-jdk-configs.noarch                                                 3.3-10.el7_5
                                                     @anaconda    
 java-1.8.0-openjdk.x86_64                                               1:1.8.0.292.b10-1.el7_9                                         @updates     
+fakepackagesplitacross3lines-1.8.0-openjdk.x86_64 
+                                              1:1.8.0.292.b10-1.el7_9
+                                                                                       @updates     

--- a/services/packages/server/testdata/yum-installed.textproto
+++ b/services/packages/server/testdata/yum-installed.textproto
@@ -22,3 +22,11 @@ packages : <
   version : "1.8.0.292.b10"
   repo : "@updates"
 >
+packages : <
+  name : "fakepackagesplitacross3lines-1.8.0-openjdk"
+  epoch: 1
+  release: "1.el7_9"
+  architecture: "x86_64"
+  version : "1.8.0.292.b10"
+  repo : "@updates"
+>


### PR DESCRIPTION
The previous code supported a too-long version name or a too-long package name, but not both at the same time.