### PR TITLE
Add linter configuration to ignore grpc deprecation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,12 @@
+issues:
+  exclude-rules:
+    # https://github.com/grpc/grpc-go/issues/7090
+    # Newer versions of grpc deprecate some commonly-used functions.
+    # Let's silence the deprecation notice until we decide to stop
+    # using them.
+    - linters:
+        - staticcheck
+      text: "SA1019: grpc.DialContext is deprecated"
+    - linters:
+        - staticcheck
+      text: "SA1019: grpc.WithBlock is deprecated"


### PR DESCRIPTION
grpc 1.64 deprecates grpc.DialContext, which is used extensively throughout this repo. Let's silence that deprecation notice until the repo no longer uses it.

This should let https://github.com/Snowflake-Labs/sansshell/pull/435 succeed