### PR TITLE
Add a way for sansshell-server to reload credentials on SIGHUP

### DIFF
--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -178,5 +178,6 @@ func main() {
 		server.WithDebugPort(*debugport),
 		server.WithMetricsPort(*metricsport),
 		server.WithMetricsRecorder(recorder),
+		server.WithRefreshCredsOnSIGHUP(),
 	)
 }


### PR DESCRIPTION
sansshell-server often runs on VMs and occasionally we have use cases where we want to change trust configuration on the running VMs. Before this PR, the only way to make sansshell-server immediately respect the trust configuration was to restart it. After this PR, it's possible to reload without restarting.

This is especially useful if the command to change the trust configuration is being run through sansshell itself.

It's slightly unusual that we're using this to reload credentials but not to reload policy files. We haven't seen any demand for reloading policy files, so I think that's an okay tradeoff.