### PR TITLE
Add a `raw call` subcommand

### DIFF
--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/Snowflake-Labs/sansshell/services/packages/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/power/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/process/client"
+	_ "github.com/Snowflake-Labs/sansshell/services/raw/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/sansshell/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/service/client"
 	_ "github.com/Snowflake-Labs/sansshell/services/sysinfo/client"

--- a/services/raw/client/client.go
+++ b/services/raw/client/client.go
@@ -1,0 +1,294 @@
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+// Package client provides subcommands that use proto reflection to
+// call other services built into sansshell.
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/google/subcommands"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/Snowflake-Labs/sansshell/client"
+	"github.com/Snowflake-Labs/sansshell/services/util"
+)
+
+const subPackage = "raw"
+
+func init() {
+	subcommands.Register(&rawCmd{}, subPackage)
+}
+
+func (*rawCmd) GetSubpackage(f *flag.FlagSet) *subcommands.Commander {
+	c := client.SetupSubpackage(subPackage, f)
+	c.Register(&callCmd{}, "")
+	return c
+}
+
+type rawCmd struct{}
+
+func (*rawCmd) Name() string { return subPackage }
+func (p *rawCmd) Synopsis() string {
+	return client.GenerateSynopsis(p.GetSubpackage(flag.NewFlagSet("", flag.ContinueOnError)), 2)
+}
+func (p *rawCmd) Usage() string {
+	return client.GenerateUsage(subPackage, p.Synopsis())
+}
+func (*rawCmd) SetFlags(f *flag.FlagSet) {}
+
+func (p *rawCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	c := p.GetSubpackage(f)
+	return c.Execute(ctx, args...)
+}
+
+type repeatedString []string
+
+func (i *repeatedString) String() string {
+	if i == nil {
+		return "[]"
+	}
+	return fmt.Sprint([]string(*i))
+}
+
+func (i *repeatedString) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+// decodeExactlyOne decodes a single json message from the decoder and
+// fails if more messages are present.
+func decodeExactlyOne(decoder *json.Decoder, msg proto.Message) error {
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("unable to read input message: %v", err)
+	}
+	if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
+		return fmt.Errorf("unable to parse input json: %v", err)
+	}
+	if decoder.More() {
+		return fmt.Errorf("more than one input object provided for non-streaming call")
+	}
+	return nil
+}
+
+func printOutput(state *util.ExecuteState, resp *proxyResponse) {
+	if resp.Error == io.EOF {
+		// Streaming commands may return EOF
+		return
+	}
+	if resp.Error != nil {
+		fmt.Fprintf(state.Err[resp.Index], "%v\n", resp.Error)
+		return
+	}
+	prettyPrinted := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Format(resp.Resp)
+	fmt.Fprintln(state.Out[resp.Index], prettyPrinted)
+}
+
+func printAllFromStream(state *util.ExecuteState, stream streamingClientProxy) error {
+	for {
+		rs, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		for _, r := range rs {
+			printOutput(state, r)
+		}
+	}
+
+}
+
+type callCmd struct {
+	metadata repeatedString
+}
+
+func (*callCmd) Name() string     { return "call" }
+func (*callCmd) Synopsis() string { return "Call sansshell-server with a hand-written RPC request" }
+func (*callCmd) Usage() string {
+	return `call <method> [json-encoded-request]:
+  Call sansshell-server with a hand-written RPC request. The request can be provided either
+  as an argument to the command or through stdin. The method being called must be from a
+  proto definition compiled into sanssh.
+
+  Examples:
+    sanssh raw call /HealthCheck.HealthCheck/Ok '{}'
+	echo '{"command":"/bin/echo", "args":["Hello World"]}' | sanssh raw call /Exec.Exec/Run
+
+`
+}
+
+func (p *callCmd) SetFlags(f *flag.FlagSet) {
+	f.Var(&p.metadata, "metadata", "key=value pair for setting in GRPC metadata separated, may be specified multiple times.")
+}
+
+func (p *callCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	state := args[0].(*util.ExecuteState)
+	proxy := genericClientProxy{state.Conn}
+
+	for _, m := range p.metadata {
+		pair := strings.SplitN(m, "=", 2)
+		if len(pair) != 2 {
+			fmt.Fprintf(os.Stderr, "metadata %v is missing equals sign\n", m)
+			return subcommands.ExitUsageError
+
+		}
+		ctx = metadata.AppendToOutgoingContext(ctx, pair[0], pair[1])
+	}
+
+	var input *json.Decoder
+	switch f.NArg() {
+	case 0:
+		fmt.Fprintln(os.Stderr, "Please specify a method name, like /HealthCheck.HealthCheck/Ok.")
+		return subcommands.ExitUsageError
+	case 1:
+		input = json.NewDecoder(os.Stdin)
+	case 2:
+		input = json.NewDecoder(strings.NewReader(f.Arg(1)))
+	default:
+		fmt.Fprintln(os.Stderr, "Too many args provided, should be <method name> <request>")
+		return subcommands.ExitUsageError
+	}
+
+	// Find our method
+	methodName := f.Arg(0)
+	var methodDescriptor protoreflect.MethodDescriptor
+	var allMethodNames []string
+	protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		svcs := fd.Services()
+		for i := 0; i < svcs.Len(); i++ {
+			svc := svcs.Get(i)
+			methods := svc.Methods()
+			for i := 0; i < methods.Len(); i++ {
+				method := methods.Get(i)
+				fullName := fmt.Sprintf("/%s/%s", svc.FullName(), method.Name())
+				if fullName == methodName {
+					// We found the right one, no need to continue
+					methodDescriptor = method
+					return false
+				}
+				allMethodNames = append(allMethodNames, fullName)
+			}
+		}
+		return true
+	})
+	if methodDescriptor == nil {
+		sort.Strings(allMethodNames)
+		fmt.Fprintf(os.Stderr, "Unknown method %q, known ones are %v\n", methodName, allMethodNames)
+		return subcommands.ExitUsageError
+	}
+
+	// Figure out the proto types to use for requests and responses.
+	inType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Input().FullName())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to find %v in protoregistry: %v\n", methodDescriptor.Input().FullName(), err)
+		return subcommands.ExitFailure
+	}
+	outType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Output().FullName())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to find %v in protoregistry: %v\n", methodDescriptor.Output().FullName(), err)
+		return subcommands.ExitFailure
+	}
+
+	// Make our actual call, using different ways based on the streaming options.
+	if methodDescriptor.IsStreamingClient() {
+		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+
+		var g errgroup.Group
+
+		g.Go(func() error {
+			for input.More() {
+				var raw json.RawMessage
+				if err := input.Decode(&raw); err != nil {
+					return fmt.Errorf("unable to read input message: %v", err)
+				}
+				msg := inType.New().Interface()
+				if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
+					return fmt.Errorf("unable to parse input json: %v", err)
+				}
+				if err := stream.SendMsg(msg); err != nil {
+					return err
+				}
+			}
+			return stream.CloseSend()
+		})
+		g.Go(func() error { return printAllFromStream(state, stream) })
+		if err := g.Wait(); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+	} else if !methodDescriptor.IsStreamingClient() && methodDescriptor.IsStreamingServer() {
+		in := inType.New().Interface()
+		if err := decodeExactlyOne(input, in); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitUsageError
+		}
+
+		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+		if err := stream.SendMsg(in); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+		if err := stream.CloseSend(); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+		if err := printAllFromStream(state, stream); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+	} else {
+		// It's a unary call if neither client or server has streams.
+		in := inType.New().Interface()
+		if err := decodeExactlyOne(input, in); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitUsageError
+		}
+		resp, err := proxy.UnaryOneMany(ctx, methodName, in, outType)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return subcommands.ExitFailure
+		}
+		for r := range resp {
+			printOutput(state, r)
+		}
+
+	}
+	return subcommands.ExitSuccess
+}

--- a/services/raw/client/client_test.go
+++ b/services/raw/client/client_test.go
@@ -1,0 +1,198 @@
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
+	"github.com/Snowflake-Labs/sansshell/services"
+	"github.com/Snowflake-Labs/sansshell/services/util"
+	"github.com/google/subcommands"
+	"github.com/gowebpki/jcs"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	// Used by our tests
+	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck/server"
+	_ "github.com/Snowflake-Labs/sansshell/services/localfile/server"
+)
+
+var (
+	bufSize = 1024 * 1024
+	lis     *bufconn.Listener
+)
+
+func bufDialer(context.Context, string) (net.Conn, error) {
+	return lis.Dial()
+}
+
+func TestMain(m *testing.M) {
+	lis = bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	for _, svc := range services.ListServices() {
+		svc.Register(s)
+	}
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+	defer s.GracefulStop()
+
+	os.Exit(m.Run())
+}
+
+// deterministicJSON reformats an input of 0 or more json objects
+// to be deterministic. Normal protojson unmarshalling is explicitly
+// nondeterministic.
+func deterministicJSON(in []byte) ([]byte, error) {
+	var out []byte
+	dec := json.NewDecoder(bytes.NewReader(in))
+	for dec.More() {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return nil, err
+		}
+		got, err := jcs.Transform([]byte(raw))
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, got...)
+	}
+	return out, nil
+}
+
+func TestRPCs(t *testing.T) {
+	ctx := context.Background()
+
+	f, err := os.CreateTemp("", "sansshell-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := f.Name()
+	defer os.Remove(tmpFile)
+	fmt.Fprintln(f, "hi")
+	f.Close()
+
+	// Dial out to sansshell server set up in TestMain
+	conn, err := proxy.DialContext(ctx, "", []string{"bufnet"}, grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	for _, tc := range []struct {
+		desc           string
+		args           []string
+		want           string
+		wantExitStatus subcommands.ExitStatus
+	}{
+		{
+			desc: "unary RPC",
+			args: []string{"/HealthCheck.HealthCheck/Ok", "{}"},
+			want: "{}",
+		},
+		{
+			desc: "with metadata",
+			args: []string{"-metadata=foo=bar", "-metadata=baz=qux", "/HealthCheck.HealthCheck/Ok", "{}"},
+			want: "{}",
+		},
+		{
+			desc: "server-streaming RPC",
+			args: []string{
+				"/LocalFile.LocalFile/Read",
+				`{"file":{"filename": "` + tmpFile + `"}}`,
+			},
+			want: `{"contents":"aGkK"}`,
+		},
+		{
+			desc: "bidirectional-streaming RPC",
+			args: []string{
+				"/LocalFile.LocalFile/Sum",
+				`{"filename": "` + tmpFile + `"}`,
+			},
+			want: `{"filename":"` + tmpFile + `","sum":"98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","sum_type":"SUM_TYPE_SHA256"}`,
+		},
+		{
+			desc: "bidirectional-streaming RPC with multiple messages",
+			args: []string{
+				"/LocalFile.LocalFile/Sum",
+				`{"filename": "` + tmpFile + `"}
+				  {"filename": "` + tmpFile + `"}`,
+			},
+			want: `{"filename":"` + tmpFile + `","sum":"98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","sum_type":"SUM_TYPE_SHA256"}{"filename":"` + tmpFile + `","sum":"98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4","sum_type":"SUM_TYPE_SHA256"}`,
+		},
+		{
+			desc:           "nonexistent message",
+			args:           []string{"/Wrong", "{}"},
+			wantExitStatus: subcommands.ExitUsageError,
+		},
+		{
+			desc:           "too few args",
+			args:           []string{},
+			wantExitStatus: subcommands.ExitUsageError,
+		},
+		{
+			desc:           "too many args",
+			args:           []string{"/HealthCheck.HealthCheck/Ok", "{}", "{}"},
+			wantExitStatus: subcommands.ExitUsageError,
+		},
+		{
+			desc:           "bad metadata",
+			args:           []string{"-metadata=foo", "/HealthCheck.HealthCheck/Ok", "{}"},
+			wantExitStatus: subcommands.ExitUsageError,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			var output bytes.Buffer
+			f := flag.NewFlagSet("call", flag.PanicOnError)
+			p := &callCmd{}
+			p.SetFlags(f)
+			if err := f.Parse(tc.args); err != nil {
+				t.Fatalf("unable to set flags: %v", err)
+			}
+			res := p.Execute(ctx, f, &util.ExecuteState{
+				Conn: conn,
+				Out:  []io.Writer{&output},
+				Err:  []io.Writer{os.Stderr},
+			})
+
+			if res != tc.wantExitStatus {
+				t.Errorf("unexpected subcommand status %v", res)
+			}
+
+			got, err := deterministicJSON(output.Bytes())
+			if err != nil {
+				t.Error(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/raw/client/grpcproxy.go
+++ b/services/raw/client/grpcproxy.go
@@ -1,0 +1,179 @@
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// genericClientProxy is similar to generated sansshell proxy code but works with generic protobufs.
+// This code is largely copied from the generated grpcproxy code.
+type genericClientProxy struct {
+	conn *proxy.Conn
+}
+
+// proxyResponse encapsulates a proxy data packet.
+// It includes the target, index, response and possible error returned.
+type proxyResponse struct {
+	Target string
+	// As targets can be duplicated this is the index into the slice passed to proxy.Conn.
+	Index int
+	Resp  proto.Message
+	Error error
+}
+
+// UnaryOneMany sends the same request to N destinations at once.
+// N can be a single destination.
+//
+// NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
+func (c *genericClientProxy) UnaryOneMany(ctx context.Context, method string, in proto.Message, out protoreflect.MessageType, opts ...grpc.CallOption) (<-chan *proxyResponse, error) {
+	conn := c.conn
+	ret := make(chan *proxyResponse)
+	// If this is a single case we can just use Invoke and marshal it onto the channel once and be done.
+	if len(conn.Targets) == 1 {
+		go func() {
+			out := &proxyResponse{
+				Target: conn.Targets[0],
+				Index:  0,
+				Resp:   out.New().Interface(),
+			}
+			err := conn.Invoke(ctx, method, in, out.Resp, opts...)
+			if err != nil {
+				out.Error = err
+			}
+			// Send and close.
+			ret <- out
+			close(ret)
+		}()
+		return ret, nil
+	}
+	manyRet, err := conn.InvokeOneMany(ctx, method, in, opts...)
+	if err != nil {
+		return nil, err
+	}
+	// A goroutine to retrieve untyped responses and convert them to typed ones.
+	go func() {
+		for {
+			typedResp := &proxyResponse{
+				Resp: out.New().Interface(),
+			}
+
+			resp, ok := <-manyRet
+			if !ok {
+				// All done so we can shut down.
+				close(ret)
+				return
+			}
+			typedResp.Target = resp.Target
+			typedResp.Index = resp.Index
+			typedResp.Error = resp.Error
+			if resp.Error == nil {
+				if err := resp.Resp.UnmarshalTo(typedResp.Resp); err != nil {
+					typedResp.Error = fmt.Errorf("can't decode any response - %v. Original Error - %v", err, resp.Error)
+				}
+			}
+			ret <- typedResp
+		}
+	}()
+
+	return ret, nil
+}
+
+type streamingClientProxy interface {
+	Recv() ([]*proxyResponse, error)
+	grpc.ClientStream
+}
+
+type clientStreamingClientProxy struct {
+	cc         *proxy.Conn
+	directDone bool
+	outType    protoreflect.MessageType
+	grpc.ClientStream
+}
+
+func (x *clientStreamingClientProxy) Recv() ([]*proxyResponse, error) {
+	var ret []*proxyResponse
+	// If this is a direct connection the RecvMsg call is to a standard grpc.ClientStream
+	// and not our proxy based one. This means we need to receive a typed response and
+	// convert it into a single slice entry return. This ensures the OneMany style calls
+	// can be used by proxy with 1:N targets and non proxy with 1 target without client changes.
+	if x.cc.Direct() {
+		// Check if we're done. Just return EOF now. Any real error was already sent inside
+		// of a ManyResponse.
+		if x.directDone {
+			return nil, io.EOF
+		}
+		m := x.outType.New().Interface()
+		err := x.ClientStream.RecvMsg(m)
+		ret = append(ret, &proxyResponse{
+			Resp:   m,
+			Error:  err,
+			Target: x.cc.Targets[0],
+			Index:  0,
+		})
+		// An error means we're done so set things so a later call now gets an EOF.
+		if err != nil {
+			x.directDone = true
+		}
+		return ret, nil
+	}
+
+	m := []*proxy.Ret{}
+	if err := x.ClientStream.RecvMsg(&m); err != nil {
+		return nil, err
+	}
+	for _, r := range m {
+		typedResp := &proxyResponse{
+			Resp: x.outType.New().Interface(),
+		}
+		typedResp.Target = r.Target
+		typedResp.Index = r.Index
+		typedResp.Error = r.Error
+		if r.Error == nil {
+			if err := r.Resp.UnmarshalTo(typedResp.Resp); err != nil {
+				typedResp.Error = fmt.Errorf("can't decode any response - %v. Original Error - %v", err, r.Error)
+			}
+		}
+		ret = append(ret, typedResp)
+	}
+	return ret, nil
+}
+
+// StreamingOneMany sends the same request to N destinations at once.
+// N can be a single destination.
+//
+// NOTE: The returned channel must be read until it closes in order to avoid leaking goroutines.
+func (c *genericClientProxy) StreamingOneMany(ctx context.Context, method string, methodDescriptor protoreflect.MethodDescriptor, out protoreflect.MessageType, opts ...grpc.CallOption) (streamingClientProxy, error) {
+	streamDesc := &grpc.StreamDesc{
+		StreamName:    string(methodDescriptor.Name()),
+		ClientStreams: methodDescriptor.IsStreamingClient(),
+		ServerStreams: methodDescriptor.IsStreamingServer(),
+	}
+	stream, err := c.conn.NewStream(ctx, streamDesc, method, opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &clientStreamingClientProxy{c.conn, false, out, stream}
+	return x, nil
+}


### PR DESCRIPTION
This adds a way to call RPCs by passing json representations of the protobufs, similar to a tool like grpcurl. Building this into `sanssh` means that normal `sanssh` code can handle things like authentication and speaking the proxy protocol properly. This subcommand is mostly meant for debuggability and isn't one I expect most people will need.

This subcommand and the `raw` module are unusual because there's no new server or proxy implementation. Instead, it leans on how importing proto code has a side effect of registering the protos in a global registry.

Unary and streaming RPCs are both supported. Input data can be provided inline or come from stdin. Here's some examples of how it gets used.

Simple call:
```
$ go run ./cmd/sanssh -targets localhost raw call /HealthCheck.HealthCheck/Ok '{}'
{}
```

More complex output, going through proxy:
```
$ go run ./cmd/sanssh -h -proxy localhost -targets localhost,localhost:9999 raw call /Dns.Lookup/Lookup '{"hostname":"www.google.com"}'
1-localhost:9999: {
1-localhost:9999:   "result":  [
1-localhost:9999:     "142.251.32.36"
1-localhost:9999:   ]
1-localhost:9999: }
0-localhost:50042: {
0-localhost:50042:   "result":  [
0-localhost:50042:     "142.251.32.36"
0-localhost:50042:   ]
0-localhost:50042: }
```

Streaming output and using stdin, also shows how bytes types are base64 encoded:

```
$ echo '{"command":"/bin/sh", "args":["-c", "echo hi; sleep 0.5; echo ho"]}' | go run ./cmd/sanssh -h -proxy localhost -targets localhost,localhost:9999 raw call /Exec.Exec/StreamingRun 
1-localhost:9999: {
1-localhost:9999:   "stdout":  "aGkK"
1-localhost:9999: }
0-localhost:50042: {
0-localhost:50042:   "stdout":  "aGkK"
0-localhost:50042: }
1-localhost:9999: {
1-localhost:9999:   "stdout":  "aG8K"
1-localhost:9999: }
0-localhost:50042: {
0-localhost:50042:   "stdout":  "aG8K"
0-localhost:50042: }
```

Bidirectional streaming:

```
$ go run ./cmd/sanssh -h -proxy localhost -targets localhost raw call /LocalFile.LocalFile/Stat '{"filename": "/etc/resolv.conf"} {"filename": "/etc/hosts"}'
0-localhost:50042: {
0-localhost:50042:   "filename":  "/etc/resolv.conf",
0-localhost:50042:   "size":  "39",
0-localhost:50042:   "mode":  134218239,
0-localhost:50042:   "modtime":  "2023-03-07T23:13:04.990258923Z",
0-localhost:50042:   "immutable":  true
0-localhost:50042: }
0-localhost:50042: {
0-localhost:50042:   "filename":  "/etc/hosts",
0-localhost:50042:   "size":  "384",
0-localhost:50042:   "mode":  420,
0-localhost:50042:   "modtime":  "2023-11-29T10:34:49Z",
0-localhost:50042:   "immutable":  true
0-localhost:50042: }
```

Bad call:
```
$ go run ./cmd/sanssh -targets localhost raw call /Wrong
Unknown method "/Wrong", known ones are [/Ansible.Playbook/Run /Dns.Lookup/Lookup /Exec.Exec/Run /Exec.Exec/StreamingRun /Fdb.CLI/FDBCLI /Fdb.Conf/Delete /Fdb.Conf/Read /Fdb.Conf/Write /Fdb.FDBMove/FDBMoveDataCopy /Fdb.FDBMove/FDBMoveDataWait /Fdb.Server/FDBServer /HTTPOverRPC.HTTPOverRPC/Host /HealthCheck.HealthCheck/Ok /LocalFile.LocalFile/Copy /LocalFile.LocalFile/List /LocalFile.LocalFile/Mkdir /LocalFile.LocalFile/Read /LocalFile.LocalFile/Readlink /LocalFile.LocalFile/Rename /LocalFile.LocalFile/Rm /LocalFile.LocalFile/Rmdir /LocalFile.LocalFile/SetFileAttributes /LocalFile.LocalFile/Stat /LocalFile.LocalFile/Sum /LocalFile.LocalFile/Symlink /LocalFile.LocalFile/Write /Mpa.Mpa/Approve /Mpa.Mpa/Clear /Mpa.Mpa/Get /Mpa.Mpa/List /Mpa.Mpa/Store /Mpa.Mpa/WaitForApproval /Packages.Packages/Cleanup /Packages.Packages/Install /Packages.Packages/ListInstalled /Packages.Packages/Remove /Packages.Packages/RepoList /Packages.Packages/Search /Packages.Packages/Update /Power.Power/Reboot /Process.Process/GetJavaStacks /Process.Process/GetMemoryDump /Process.Process/GetStacks /Process.Process/Kill /Process.Process/List /Proxy.Proxy/Proxy /Sansshell.Logging/GetVerbosity /Sansshell.Logging/SetVerbosity /Sansshell.State/Version /Service.Service/Action /Service.Service/List /Service.Service/Status /SysInfo.SysInfo/Dmesg /SysInfo.SysInfo/Journal /SysInfo.SysInfo/Uptime /TLSInfo.TLSInfo/GetTLSCertificate]
exit status 1
```