### PR TITLE
Change packages list command output to satisfy NEVRA format

### DIFF
--- a/services/packages/client/client.go
+++ b/services/packages/client/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/Snowflake-Labs/sansshell/services/packages/client/domain"
 	"os"
 	"sort"
 	"strings"
@@ -359,11 +360,7 @@ func (l *listCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 		}
 		if l.nevra {
 			for _, pkg := range r.Resp.Packages {
-				ne := pkg.Name
-				if pkg.Epoch != 0 {
-					ne = fmt.Sprintf("%s-%d", pkg.Name, pkg.Epoch)
-				}
-				nevra := fmt.Sprintf("%v:%v-%v.%v", ne, pkg.Version, pkg.Release, pkg.Architecture)
+				nevra := domain.ToNevraStr(pkg)
 				fmt.Fprintln(state.Out[r.Index], nevra)
 			}
 		} else {
@@ -384,6 +381,7 @@ func (l *listCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 				fmt.Fprintf(state.Out[r.Index], "%40s %16s %32s\n", na, evr, pkg.Repo)
 			}
 		}
+		fmt.Fprintln(os.Stdout)
 	}
 	return retCode
 }
@@ -463,7 +461,8 @@ func (l *searchCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 				fmt.Fprintf(state.Out[r.Index], "%-10s%s\n", " ", "No package found!")
 			} else {
 				for _, packageInfo := range packages {
-					fmt.Fprintf(state.Out[r.Index], "%-10s%s-%d:%s-%s.%s\n", " ", packageInfo.Name, packageInfo.Epoch, packageInfo.Version, packageInfo.Release, packageInfo.Architecture)
+					nevra := domain.ToNevraStr(packageInfo)
+					fmt.Fprintf(state.Out[r.Index], "%-10s%s\n", " ", nevra)
 				}
 			}
 
@@ -474,7 +473,8 @@ func (l *searchCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interf
 				fmt.Fprintf(state.Out[r.Index], "%-10s%s\n", " ", "No package found!")
 			} else {
 				for _, packageInfo := range packages {
-					fmt.Fprintf(state.Out[r.Index], "%-10s%s-%d:%s-%s.%s\n", " ", packageInfo.Name, packageInfo.Epoch, packageInfo.Version, packageInfo.Release, packageInfo.Architecture)
+					nevra := domain.ToNevraStr(packageInfo)
+					fmt.Fprintf(state.Out[r.Index], "%-10s%s\n", " ", nevra)
 				}
 			}
 		}

--- a/services/packages/client/domain/package.domain-service.go
+++ b/services/packages/client/domain/package.domain-service.go
@@ -1,0 +1,28 @@
+/* Copyright (c) 2019 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package domain
+
+import (
+	"fmt"
+	pb "github.com/Snowflake-Labs/sansshell/services/packages"
+)
+
+// ToNevraStr convert [pb.PackageInfo] into NEVRA formated string.
+// It usually used to install/update packages or compare their version and builds.
+func ToNevraStr(pkg *pb.PackageInfo) string {
+	return fmt.Sprintf("%s-%d:%s-%s.%s", pkg.Name, pkg.Epoch, pkg.Version, pkg.Release, pkg.Architecture)
+}

--- a/services/packages/client/domain/package.domain-service_test.go
+++ b/services/packages/client/domain/package.domain-service_test.go
@@ -1,0 +1,58 @@
+/* Copyright (c) 2019 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package domain
+
+import (
+	pb "github.com/Snowflake-Labs/sansshell/services/packages"
+	"testing"
+)
+
+func TestToNevraStr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pb.PackageInfo
+		expected string
+	}{
+		{
+			name:     "It should convert package info to NEVRA string",
+			input:    &pb.PackageInfo{Name: "test", Epoch: 1, Version: "1.0.0", Release: "1", Architecture: "x86_64"},
+			expected: "test-1:1.0.0-1.x86_64",
+		},
+		{
+			name:     "It should convert package info to NEVRA string, in case of epoch is 0",
+			input:    &pb.PackageInfo{Name: "test", Epoch: 0, Version: "1.0.0", Release: "1", Architecture: "x86_64"},
+			expected: "test-0:1.0.0-1.x86_64",
+		},
+		{
+			name:     "It should convert package info to NEVRA string, in case of version is not in XX.XX.XX format",
+			input:    &pb.PackageInfo{Name: "test", Epoch: 0, Version: "1.10.22_rc-2", Release: "1", Architecture: "x86_64"},
+			expected: "test-0:1.10.22_rc-2-1.x86_64",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// ACT
+			result := ToNevraStr(test.input)
+
+			// ASSERT
+			if result != test.expected {
+				t.Errorf("Expected %s, but provided %s", test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I had changed `packages list --nevra` logic to use the NEVRA format. Also I extract it to separate domain function to be able to reuse across service and cover with tests

## Is it was tests
I proves that old `search` implementation and new `search`/`list` print package versions in the same format
I proves that on remote machine it is possible to get name-version from list and use it in update
