### PR TITLE
Expose Unix Domain Socket from server for local access

### DIFF
--- a/cmd/sansshell-server/main.go
+++ b/cmd/sansshell-server/main.go
@@ -87,6 +87,7 @@ var (
 	hostport      = flag.String("hostport", "localhost:50042", "Where to listen for connections.")
 	debugport     = flag.String("debugport", "localhost:50044", "A separate port for http debug pages. Set to an empty string to disable.")
 	metricsport   = flag.String("metricsport", "localhost:50047", "A separate port for http debug pages. Set to an empty string to disable.")
+	unixSocket    = flag.String("unix-socket", "", "Path to a Unix socket to listen on in addition to hostport. The socket supports plaintext (non-TLS) communication. Set to an empty string to disable.")
 	credSource    = flag.String("credential-source", mtlsFlags.Name(), fmt.Sprintf("Method used to obtain mTLS credentials (one of [%s])", strings.Join(mtls.Loaders(), ",")))
 	verbosity     = flag.Int("v", 0, "Verbosity level. > 0 indicates more extensive logging")
 	validate      = flag.Bool("validate", false, "If true will evaluate the policy and then exit (non-zero on error)")
@@ -170,6 +171,7 @@ func main() {
 		server.WithLogger(logger),
 		server.WithCredSource(*credSource),
 		server.WithHostPort(*hostport),
+		server.WithUnixSocket(*unixSocket),
 		server.WithParsedPolicy(parsed),
 		server.WithJustification(*justification),
 		server.WithAuthzHook(rpcauth.PeerPrincipalFromCertHook()),

--- a/server/server.go
+++ b/server/server.go
@@ -20,11 +20,14 @@ package server
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net"
+	"os"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/stats"
 
 	"github.com/Snowflake-Labs/sansshell/auth/opa"
@@ -63,6 +66,11 @@ func WithCredentials(c credentials.TransportCredentials) Option {
 		s.creds = c
 		return nil
 	})
+}
+
+// WithInsecure specifies that transport security should be disabled.
+func WithInsecure() Option {
+	return WithCredentials(insecure.NewCredentials())
 }
 
 // WithPolicy applies an OPA policy used against incoming RPC requests.
@@ -146,22 +154,57 @@ func WithOnStartListener(h func(*grpc.Server)) Option {
 	})
 }
 
-// Serve wraps up BuildServer in a succinct API for callers passing along various parameters. It will automatically add
-// an authz hook for HostNet based on the listener address. Additional hooks are passed along after this one.
+// Serve starts and runs a server on the given hostport.
 func Serve(hostport string, opts ...Option) error {
 	lis, err := net.Listen("tcp", hostport)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %v", err)
 	}
+	return serveListener(lis, opts...)
+}
 
-	h := rpcauth.HostNetHook(lis.Addr())
+// ServeUnix runs a server on a Unix socket. If the socket path exists, it will be removed beforehand.
+func ServeUnix(socketPath string, socketConfigHook func(string) error, opts ...Option) error {
+	// If the socket path exists, remove it, but error out if it is not a socket.
+	if stat, err := os.Stat(socketPath); err == nil {
+		if stat.Mode().Type() != fs.ModeSocket {
+			return fmt.Errorf("Unix socket path exists and is not a socket: %s", socketPath)
+		}
+		if err := os.Remove(socketPath); err != nil {
+			return fmt.Errorf("failed to remove existing Unix socket: %v", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat Unix socket: %v", err)
+	}
+
+	unixListener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("failed to listen on Unix socket: %v", err)
+	}
+	defer os.Remove(socketPath)
+
+	if socketConfigHook != nil {
+		if err := socketConfigHook(socketPath); err != nil {
+			return fmt.Errorf("failed to configure Unix socket: %v", err)
+		}
+	}
+
+	return serveListener(unixListener, opts...)
+}
+
+// serveListener wraps up BuildServer and runs a server for the given Listener object. It will automatically add
+// an authz hook for HostNet based on the listener address. Additional hooks are passed along after this one.
+//
+// listener will be closed when this function returns.
+func serveListener(listener net.Listener, opts ...Option) error {
+	h := rpcauth.HostNetHook(listener.Addr())
 	opts = append(opts, WithAuthzHook(h))
 	srv, err := BuildServer(opts...)
 	if err != nil {
 		return err
 	}
 
-	return srv.Serve(lis)
+	return srv.Serve(listener)
 }
 
 // BuildServer creates a gRPC server, attaches the OPA policy interceptor with supplied args and then


### PR DESCRIPTION
Apart from providing access to a node from the outside, Sansshell
could conceivably be viewed as an interface between services running
on the node and the node's operating system. For example, instead of
adding a sudoers entry to allow some operation which would normally
require root privileges, we could expose the operation as a Sansshell
gRPC method, and call it from the inside: from some process which runs
on the same node as the Sansshell server. This way, we would gain
fine-grained authorization and auditability.
    
To make this approach possible, we modify the Sansshell server to
optionally expose a Unix domain socket which offers the same gRPC
methods as the main TCP server. The server which handles the socket
does not require TLS authentication, because obtaining the proper
certificates may be difficult for local clients. This should be OK,
considering how MITM attacks using the socket would only be possible
if the node has already been compromised to some extent.
    
Unix permissions/ACLs on the socket file can be used as a security
measure. The server makes this possible by exposing a hook function
which can configure the socket's ownership and permissions once the
socket is created. This hook mechanism may be used in the future to
specify socket permissions and ownership on the server command line.
    
In the rego authentication rules, clients using the Unix socket can be
identified by having `input.peer.net.network = "unix"`.