### PR TITLE
Get peer credentials over Unix socket

### DIFF
--- a/auth/opa/rpcauth/rpcauth_test.go
+++ b/auth/opa/rpcauth/rpcauth_test.go
@@ -552,6 +552,41 @@ func TestRpcAuthInput(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "method and a peer context with unix creds",
+			ctx: peer.NewContext(ctx, &peer.Peer{
+				Addr: &net.UnixAddr{Net: "unix", Name: "@"},
+				AuthInfo: UnixPeerAuthInfo{
+					CommonAuthInfo: credentials.CommonAuthInfo{
+						SecurityLevel: credentials.NoSecurity,
+					},
+					Credentials: UnixPeerCredentials{
+						Uid:        1,
+						UserName:   "george",
+						Gids:       []int{1001, 2},
+						GroupNames: []string{"george", "the_gang"},
+					},
+				},
+			}),
+			method: "/AMethod",
+			compare: &RPCAuthInput{
+				Method: "/AMethod",
+				Peer: &PeerAuthInput{
+					Net: &NetAuthInput{
+						Network: "unix",
+						Address: "@",
+						Port:    "",
+					},
+					Unix: &UnixAuthInput{
+						Uid:        1,
+						UserName:   "george",
+						Gids:       []int{1001, 2},
+						GroupNames: []string{"george", "the_gang"},
+					},
+					Cert: &CertAuthInput{},
+				},
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/auth/opa/rpcauth/unix_peer_auth_info.go
+++ b/auth/opa/rpcauth/unix_peer_auth_info.go
@@ -1,0 +1,40 @@
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package rpcauth
+
+import (
+	"google.golang.org/grpc/credentials"
+)
+
+// UnixPeerCreds represents the credentials of a Unix peer.
+type UnixPeerCredentials struct {
+	Uid        int
+	Gids       []int // Primary and supplementary group IDs.
+	UserName   string
+	GroupNames []string
+}
+
+// UnixPeerAuthInfo contains the authentication information for a Unix peer,
+// in a form suitable for authentication info returned by gRPC transport credentials.
+type UnixPeerAuthInfo struct {
+	credentials.CommonAuthInfo
+	Credentials UnixPeerCredentials
+}
+
+func (UnixPeerAuthInfo) AuthType() string {
+	return "insecure_with_unix_creds"
+}

--- a/cmd/sansshell-server/server/server.go
+++ b/cmd/sansshell-server/server/server.go
@@ -401,7 +401,7 @@ func runTCPServer(ctx context.Context, rs *runState) error {
 
 func runInsecureUnixSocketServer(_ context.Context, rs *runState) error {
 	serverOpts := extractCommonOptionsFromRunState(rs)
-	serverOpts = append(serverOpts, server.WithInsecure())
+	serverOpts = append(serverOpts, server.WithCredentials(server.NewUnixPeerTransportCredentials()))
 	return server.ServeUnix(rs.unixSocket, rs.unixSocketConfigHook, serverOpts...)
 }
 

--- a/server/unix_peer_credentials.go
+++ b/server/unix_peer_credentials.go
@@ -1,0 +1,85 @@
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// unixPeerTransportCredentials is a TransportCredentials implementation that fetches the
+// peer's credentials from the Unix domain socket. Otherwise, the channel is insecure (no TLS).
+type unixPeerTransportCredentials struct {
+	insecureCredentials credentials.TransportCredentials
+}
+
+func (uc *unixPeerTransportCredentials) ClientHandshake(ctx context.Context, authority string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return uc.insecureCredentials.ClientHandshake(ctx, authority, conn)
+}
+
+func (uc *unixPeerTransportCredentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, insecureAuthInfo, err := uc.insecureCredentials.ServerHandshake(conn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	unixCreds, err := getUnixPeerCredentials(conn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get unix peer credentials: %w", err)
+	}
+	if unixCreds == nil {
+		// This means Unix credentials are not available (not a Unix system).
+		// We treat this connection as a basic insecure connection, with the
+		// authentication info coming from the 'insecure' module.
+		return conn, insecureAuthInfo, nil
+	}
+
+	unixPeerAuthInfo := rpcauth.UnixPeerAuthInfo{
+		CommonAuthInfo: credentials.CommonAuthInfo{SecurityLevel: credentials.NoSecurity},
+		Credentials:    *unixCreds,
+	}
+	return conn, unixPeerAuthInfo, nil
+}
+
+func (uc *unixPeerTransportCredentials) Info() credentials.ProtocolInfo {
+	return uc.insecureCredentials.Info()
+}
+
+func (uc *unixPeerTransportCredentials) Clone() credentials.TransportCredentials {
+	return &unixPeerTransportCredentials{
+		insecureCredentials: uc.insecureCredentials.Clone(),
+	}
+}
+
+func (uc *unixPeerTransportCredentials) OverrideServerName(serverName string) error {
+	// This is the same as the insecure implementation, but does not use
+	// its deprecated method.
+	return nil
+}
+
+// NewUnixPeerCredentials returns a new TransportCredentials that disables transport security,
+// but fetches the peer's credentials from the Unix domain socket.
+func NewUnixPeerTransportCredentials() credentials.TransportCredentials {
+	return &unixPeerTransportCredentials{
+		insecureCredentials: insecure.NewCredentials(),
+	}
+}

--- a/server/unix_peer_credentials_darwin.go
+++ b/server/unix_peer_credentials_darwin.go
@@ -1,0 +1,89 @@
+//go:build darwin
+
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os/user"
+	"strconv"
+
+	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
+	"golang.org/x/sys/unix"
+)
+
+// getUnixPeerCredentials indicates missing Unix credentials on non-Linux systems.
+//
+// This is needed so that the rpcauth package compiles on non-Linux systems,
+// where Unix credentials cannot be fetched.
+func getUnixPeerCredentials(conn net.Conn) (*rpcauth.UnixPeerCredentials, error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("called getUnixPeerCredentials on non-Unix connection")
+	}
+
+	rawConn, err := uc.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get raw connection: %w", err)
+	}
+
+	var ucred *unix.Xucred
+	err2 := rawConn.Control(func(fd uintptr) {
+		ucred, err = unix.GetsockoptXucred(int(fd),
+			unix.SOL_LOCAL,
+			unix.LOCAL_PEERCRED)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get peer credentials - getsockopt error: %w", err)
+	}
+	if err2 != nil {
+		return nil, fmt.Errorf("failed to get peer credentials - socket Control error: %w", err2)
+	}
+
+	// Convert UID and GIDs to user & group names. If any lookup fails, use the numeric value.
+	uid := int(ucred.Uid)
+	userName := strconv.Itoa(uid)
+	userInfo, err := user.LookupId(userName)
+	if err == nil {
+		userName = userInfo.Username
+	}
+
+	groupIds := []int{}
+	for _, groupId := range ucred.Groups[0:ucred.Ngroups] {
+		groupIds = append(groupIds, int(groupId))
+	}
+	groupNames := []string{}
+
+	for _, groupId := range groupIds {
+		groupIdString := strconv.Itoa(groupId)
+		groupInfo, err := user.LookupGroupId(groupIdString)
+		if err == nil {
+			groupNames = append(groupNames, groupInfo.Name)
+		} else {
+			groupNames = append(groupNames, groupIdString)
+		}
+	}
+
+	return &rpcauth.UnixPeerCredentials{
+		Uid:        uid,
+		Gids:       groupIds,
+		UserName:   userName,
+		GroupNames: groupNames,
+	}, nil
+}

--- a/server/unix_peer_credentials_linux.go
+++ b/server/unix_peer_credentials_linux.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+/* Copyright (c) 2024 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"os/user"
+	"strconv"
+
+	"github.com/Snowflake-Labs/sansshell/auth/opa/rpcauth"
+	"golang.org/x/sys/unix"
+)
+
+// getUnixPeerCredentials returns the peer's Unix credentials from the given network connection.
+//
+// The provided connection should be established over a Unix domain socket.
+func getUnixPeerCredentials(conn net.Conn) (*rpcauth.UnixPeerCredentials, error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return nil, fmt.Errorf("called getUnixPeerCredentials on non-Unix connection")
+	}
+
+	rawConn, err := uc.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get raw connection: %w", err)
+	}
+
+	var ucred *unix.Ucred
+	err2 := rawConn.Control(func(fd uintptr) {
+		ucred, err = unix.GetsockoptUcred(int(fd),
+			unix.SOL_SOCKET,
+			unix.SO_PEERCRED)
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get peer credentials - getsockopt error: %w", err)
+	}
+	if err2 != nil {
+		return nil, fmt.Errorf("failed to get peer credentials - socket Control error: %w", err2)
+	}
+
+	// Convert UID to user name, fetch primary & supplementary group IDs and convert them to group
+	// names. If any user/group lookup fails, use the numeric value.
+	uid := int(ucred.Uid)
+	userName := strconv.Itoa(uid)
+	userInfo, err := user.LookupId(userName)
+	if err == nil {
+		userName = userInfo.Username
+	}
+
+	groupIdStrings, err := userInfo.GroupIds()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get group IDs for user %s: %w", userName, err)
+	}
+	groupIds := []int{}
+	groupNames := []string{}
+
+	for _, groupIdString := range groupIdStrings {
+		groupId, err := strconv.Atoi(groupIdString)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert group ID %s to int: %w", groupIdString, err)
+		}
+		groupIds = append(groupIds, groupId)
+
+		groupInfo, err := user.LookupGroupId(groupIdString)
+		if err == nil {
+			groupNames = append(groupNames, groupInfo.Name)
+		} else {
+			groupNames = append(groupNames, groupIdString)
+		}
+	}
+
+	return &rpcauth.UnixPeerCredentials{
+		Uid:        uid,
+		Gids:       groupIds,
+		UserName:   userName,
+		GroupNames: groupNames,
+	}, nil
+}


### PR DESCRIPTION
### Pass peer credentials from Unix domain socket to authorization engine

In commit 39af558b10, we have added the possibility of exposing a Unix
domain socket to the Sansshell server. In this commit, we enhance the
authorization possibilities around this new method of communication.

Unix systems allow us to get information about the process which has
initiated a connection over a Unix socket by means of the `getsockopt`
call with the `SO_PEERCRED` option. This way, we get the UID, GID and
PID of the calling process. We pass this information into the input
structure of the OPA rules, so that rules can be written to only allow
certain local users to access a particular Sansshell gRPC method, for
example.

The method of getting client credentials in the gRPC server has been 
inspired by:
* https://groups.google.com/g/grpc-io/c/FeQV7NXpeqA/m/fCPu8qGPBQAJ
* https://blog.jbowen.dev/2019/09/using-so_peercred-in-go/

### Look up user & group name corresponding to peer Unix credentials

In addition to the numeric UID and GID values in the credentials of a
peer talking to the Sansshell server over a Unix socket, we want to
provide the human-readable user and group names. This will enable
writing more reader-friendly OPA rules based on the Unix credentials.

