### PR TITLE
Make dns available through sansshell proxy.

### DIFF
--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -46,6 +46,7 @@ import (
 
 	// Import services here to make them proxy-able
 	_ "github.com/Snowflake-Labs/sansshell/services/ansible"
+	_ "github.com/Snowflake-Labs/sansshell/services/dns"
 	_ "github.com/Snowflake-Labs/sansshell/services/exec"
 	_ "github.com/Snowflake-Labs/sansshell/services/healthcheck"
 	_ "github.com/Snowflake-Labs/sansshell/services/httpoverrpc"


### PR DESCRIPTION
At least during local development followinghttps://github.com/Snowflake-Labs/sansshell?tab=readme-ov-file#build-and-run the DNS resolution fails when calling out through proxy

```
$ go run ./cmd/sanssh --proxy=localhost:50043 --targets=localhost:50042 dns lookup www.example.com
Dns lookup failure for target localhost:50042 (0) - error - rpc error: code = Internal desc = got reply error from stream. Code: InvalidArgument Message: unknown method /Dns.Lookup/Lookup
```

while it succeeds when contacting server directly 

```
go run ./cmd/sanssh --targets=localhost dns lookup www.example.com
93.184.215.14
```

 I suspect this is due to lack of linking of dns in https://github.com/Snowflake-Labs/sansshell/blob/c38af02d48b29767949bb477f40093561f3fb914/cmd/proxy-server/main.go#L47