### PR TITLE
Fixed inconsistent parsing of `--mode` flag

### DIFF
--- a/services/localfile/README.md
+++ b/services/localfile/README.md
@@ -89,3 +89,27 @@ sanssh --target $TARGET file cp --username=joe --group=staff --mode=644 local.tx
 # Copies a file from an S3 bucket and stores it on the remote machine as `/tmp/remote.txt`
 sanssh --target $TARGET file cp --username=joe --group=staff --mode=644 --bucket=s3://my-bucket local.txt /tmp/remote.txt
 ```
+
+### sanssh file mkdir
+Create a directory at the specified path.
+
+Note: Creating intermediate directories is not supported. In order to create `/AAA/BBB/test`,
+   both `AAA` and `BBB` must exist.
+
+```bash
+sanssh <sanssh-args> file mkdir --uid=X|username=Y --gid=X|group=Y --mode=X <path>
+```
+Where:
+- `<sanssh-args>` common sanssh arguments
+- `<path>` path of the new directory
+- `--uid` The uid the remote file will be set via chown.
+- `--username` The remote file will be set to this username via chown.
+- `--gid` The gid the remote file will be set via chown.
+- `--group` The remote file will be set to this group via chown.
+- `--mode` The mode the remote file will be set via chmod. Must be an octal number (e.g. 644, 755, 0777).
+
+Examples:
+```bash
+# Creates a new `hello` directory in `/opt`
+sanssh --target $TARGET file mkdir --username=joe --group=staff --mode=644 /opt/hello
+```

--- a/services/localfile/README.md
+++ b/services/localfile/README.md
@@ -113,3 +113,20 @@ Examples:
 # Creates a new `hello` directory in `/opt`
 sanssh --target $TARGET file mkdir --username=joe --group=staff --mode=644 /opt/hello
 ```
+
+### sanssh file chmod
+Change the modes on a file/directory.
+
+```bash
+sanssh <sanssh-args> file chmod --mode=X <path>
+```
+Where:
+- `<sanssh-args>` common sanssh arguments
+- `<path>` path of the new directory
+- `--mode` The mode the remote file will be set via chmod. Must be an octal number (e.g. 644, 755, 0777).
+
+Examples:
+```bash
+# Set file mode of `/opt/hello` to 644
+sanssh --target $TARGET file chmod --mode=644 /opt/hello
+```

--- a/services/localfile/README.md
+++ b/services/localfile/README.md
@@ -58,3 +58,34 @@ sanssh --targets file set-data --format dotenv /etc/some-config "HOST" "localhos
 # Set data specified type
 sanssh --targets file set-data --value-type int /etc/config.yml "database.port" 8080
 ```
+
+### sanssh file cp
+Copy the source file (which can be local or a URL such as --bucket=s3://bucket <source> or --bucket=file://directory <source>) to the target(s)
+placing it into the remote destination.
+
+NOTE: Using file:// means the file must be in that location on each remote target in turn as no data is transferred in that case. Also make
+sure to use a fully formed directory. i.e. copying /etc/hosts would be --bucket=file:///etc hosts <destination>
+
+```bash
+sanssh <sanssh-args> file cp --uid=X|username=Y --gid=X|group=Y --mode=X [--bucket=XXX] [--overwrite] [--immutable] <source> <remote destination>
+```
+Where:
+- `<sanssh-args>` common sanssh arguments
+- `<source>` path to a file to copy from (can be local path or a URL)
+- `<remote destination>` path to a file to copy to on a remote machine
+- `--uid` The uid the remote file will be set via chown.
+- `--username` The remote file will be set to this username via chown.
+- `--gid` The gid the remote file will be set via chown.
+- `--group` The remote file will be set to this group via chown.
+- `--mode` The mode the remote file will be set via chmod. Must be an octal number (e.g. 644, 755, 0777).
+- `--bucket` If set to a valid prefix will copy from this bucket with the key being the source provided
+- `--overwrite` If true will overwrite the remote file. Otherwise the file pre-existing is an error.
+- `--immutable` If true sets the remote file to immutable after being written.
+
+Examples:
+```bash
+# Copies a local file `local.txt` and stores it on the remote machine as `/tmp/remote.txt`
+sanssh --target $TARGET file cp --username=joe --group=staff --mode=644 local.txt /tmp/remote.txt
+# Copies a file from an S3 bucket and stores it on the remote machine as `/tmp/remote.txt`
+sanssh --target $TARGET file cp --username=joe --group=staff --mode=644 --bucket=s3://my-bucket local.txt /tmp/remote.txt
+```

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -26,6 +26,7 @@ import (
 	"io/fs"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -766,7 +767,7 @@ func (c *chmodCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 		return subcommands.ExitFailure
 	}
 
-	mode, err := ParseFileMode(c.mode)
+	mode, err := parseFileMode(c.mode)
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", c.mode)
@@ -1066,7 +1067,7 @@ func (p *cpCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{
 		}
 	}
 
-	mode, err := ParseFileMode(p.mode)
+	mode, err := parseFileMode(p.mode)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", p.mode)
@@ -1412,7 +1413,7 @@ func (p *mkdirCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 	c := pb.NewLocalFileClientProxy(state.Conn)
 	directoryName := f.Args()[0]
 
-	mode, err := ParseFileMode(p.mode)
+	mode, err := parseFileMode(p.mode)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", p.mode)
@@ -1481,4 +1482,12 @@ func (p *mkdirCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 	}
 	return retCode
 
+}
+
+const fileModeSizeInBits = 12
+
+func parseFileMode(modeStr string) (uint16, error) {
+	mode, err := strconv.ParseUint(modeStr, 8, fileModeSizeInBits)
+
+	return uint16(mode), err
 }

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -752,7 +752,7 @@ func (*chmodCmd) Usage() string {
 }
 
 func (c *chmodCmd) SetFlags(f *flag.FlagSet) {
-	f.StringVar(&c.mode, "mode", "", "Sets the file/directory to this mode")
+	f.StringVar(&c.mode, "mode", "", "Sets the file/directory to this mode. Must be an octal number (e.g. 644, 755, 0777).")
 }
 
 func (c *chmodCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
@@ -1013,7 +1013,7 @@ func (p *cpCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.overwrite, "overwrite", false, "If true will overwrite the remote file. Otherwise the file pre-existing is an error.")
 	f.IntVar(&p.uid, "uid", -1, "The uid the remote file will be set via chown.")
 	f.IntVar(&p.gid, "gid", -1, "The gid the remote file will be set via chown.")
-	f.StringVar(&p.mode, "mode", "", "The mode the remote file will be set via chmod.")
+	f.StringVar(&p.mode, "mode", "", "The mode the remote file will be set via chmod. Must be an octal number (e.g. 644, 755, 0777).")
 	f.BoolVar(&p.immutable, "immutable", false, "If true sets the remote file to immutable after being written.")
 	f.StringVar(&p.username, "username", "", "The remote file will be set to this username via chown.")
 	f.StringVar(&p.group, "group", "", "The remote file will be set to this group via chown.")
@@ -1385,7 +1385,7 @@ func (*mkdirCmd) Usage() string {
 func (p *mkdirCmd) SetFlags(f *flag.FlagSet) {
 	f.IntVar(&p.uid, "uid", -1, "The uid the remote file will be set via chown.")
 	f.IntVar(&p.gid, "gid", -1, "The gid the remote file will be set via chown.")
-	f.StringVar(&p.mode, "mode", "", "The mode the remote file will be set via chmod.")
+	f.StringVar(&p.mode, "mode", "", "The mode the remote file will be set via chmod. Must be an octal number (e.g. 644, 755, 0777).")
 	f.StringVar(&p.username, "username", "", "The remote file will be set to this username via chown.")
 	f.StringVar(&p.group, "group", "", "The remote file will be set to this group via chown.")
 }

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -769,7 +769,7 @@ func (c *chmodCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 	mode, err := ParseFileMode(c.mode)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid --mode %s", c.mode)
+		fmt.Fprintln(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", c.mode)
 
 		return subcommands.ExitUsageError
 	}
@@ -1069,7 +1069,7 @@ func (p *cpCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{
 	mode, err := ParseFileMode(p.mode)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid --mode %s", p.mode)
+		fmt.Fprintf(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", p.mode)
 
 		return subcommands.ExitUsageError
 	}
@@ -1415,7 +1415,7 @@ func (p *mkdirCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 	mode, err := ParseFileMode(p.mode)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Invalid --mode %s", p.mode)
+		fmt.Fprintf(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", p.mode)
 
 		return subcommands.ExitUsageError
 	}

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -1377,7 +1377,7 @@ func (*mkdirCmd) Usage() string {
   Create a directory at the specified path.
   Note:
   1. Please set flags before path.
-  2. The action doesn't support creating intermedaite directories, e.g for this path /AAA/BBB/test,
+  2. The action doesn't support creating intermediate directories, e.g for this path /AAA/BBB/test,
      the parent directories BBB or /AAA/BBB doesn't exist, the action won't work.
 `
 }

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -770,7 +770,7 @@ func (c *chmodCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 	mode, err := parseFileMode(c.mode)
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", c.mode)
+		fmt.Fprintf(os.Stderr, "Invalid --mode '%s'. An octal number expected (e.g. 644, 755, 0777).\n", c.mode)
 
 		return subcommands.ExitUsageError
 	}

--- a/services/localfile/client/client.go
+++ b/services/localfile/client/client.go
@@ -762,7 +762,7 @@ func (c *chmodCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfa
 		return subcommands.ExitUsageError
 	}
 	if c.mode == "" {
-		fmt.Fprintln(os.Stderr, "--mode must be set to a non-zero value")
+		fmt.Fprintln(os.Stderr, "--mode must be set to a non-empty value")
 		return subcommands.ExitFailure
 	}
 

--- a/services/localfile/client/utils.go
+++ b/services/localfile/client/utils.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strconv"
 
 	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
 	pb "github.com/Snowflake-Labs/sansshell/services/localfile"
@@ -576,4 +577,12 @@ func ListRemote(ctx context.Context, conn *proxy.Conn, listRequest ListRequest) 
 		}
 	}
 	return ret, nil
+}
+
+const fileModeSizeInBits = 12
+
+func ParseFileMode(modeStr string) (uint16, error) {
+	mode, err := strconv.ParseUint(modeStr, 8, fileModeSizeInBits)
+
+	return uint16(mode), err
 }

--- a/services/localfile/client/utils.go
+++ b/services/localfile/client/utils.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strconv"
 
 	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
 	pb "github.com/Snowflake-Labs/sansshell/services/localfile"
@@ -577,12 +576,4 @@ func ListRemote(ctx context.Context, conn *proxy.Conn, listRequest ListRequest) 
 		}
 	}
 	return ret, nil
-}
-
-const fileModeSizeInBits = 12
-
-func ParseFileMode(modeStr string) (uint16, error) {
-	mode, err := strconv.ParseUint(modeStr, 8, fileModeSizeInBits)
-
-	return uint16(mode), err
 }

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -635,8 +635,12 @@ run_a_test false 0 file immutable --state=true ${LOGS}/test-file
 
 check_perms_mode ${LOGS}/test-file
 
+# Need to make this non-immutable again or we can't change the mode.
+run_a_test false 0 file immutable --state=false ${LOGS}/test-file
+
 # Should treat mode with and without leading zero the same
 run_a_test false 0 file chmod --mode="${EXPECTED_NEW_MODE_NO_LEAD_ZERO}" ${LOGS}/test-file
+run_a_test false 0 file immutable --state=true ${LOGS}/test-file
 check_perms_mode ${LOGS}/test-file
 
 # Now do it with username/group args

--- a/testing/integrate.sh
+++ b/testing/integrate.sh
@@ -626,12 +626,17 @@ EXPECTED_NEW_IMMUTABLE="i"
 CUR=$(printf "%d\n" "${ORIG_MODE}")
 NEW=$((CUR + 1))
 EXPECTED_NEW_MODE=$(printf "0%o" "${NEW}")
+EXPECTED_NEW_MODE_NO_LEAD_ZERO=$(printf "%o" "${NEW}")
 
 run_a_test false 0 file chown --uid=${EXPECTED_NEW_UID} ${LOGS}/test-file
 run_a_test false 0 file chgrp --gid=${EXPECTED_NEW_GID} ${LOGS}/test-file
 run_a_test false 0 file chmod --mode="${EXPECTED_NEW_MODE}" ${LOGS}/test-file
 run_a_test false 0 file immutable --state=true ${LOGS}/test-file
 
+check_perms_mode ${LOGS}/test-file
+
+# Should treat mode with and without leading zero the same
+run_a_test false 0 file chmod --mode="${EXPECTED_NEW_MODE_NO_LEAD_ZERO}" ${LOGS}/test-file
 check_perms_mode ${LOGS}/test-file
 
 # Now do it with username/group args
@@ -663,6 +668,10 @@ echo "uid, etc checks passed"
 EXPECTED_NEW_UID=$((ORIG_UID + 1))
 EXPECTED_NEW_GID=$((ORIG_GID + 1))
 run_a_test false 0 file cp --overwrite --uid=${EXPECTED_NEW_UID} --gid=${EXPECTED_NEW_GID} --mode="${EXPECTED_NEW_MODE}" ${LOGS}/hosts ${LOGS}/cp-hosts
+check_perms_mode ${LOGS}/cp-hosts
+
+# Should treat mode with and without leading zero the same
+run_a_test false 0 file cp --overwrite --uid=${EXPECTED_NEW_UID} --gid=${EXPECTED_NEW_GID} --mode="${EXPECTED_NEW_MODE_NO_LEAD_ZERO}" ${LOGS}/hosts ${LOGS}/cp-hosts
 check_perms_mode ${LOGS}/cp-hosts
 
 # Now do it with username/group


### PR DESCRIPTION
Due to default Go's sting-to-int parsing algorithm the value of `--mode` flag  was treated as decimal or octal depending on its format (`777` vs. `0777`), which was yielding unexpected results and was inconsistent with how native UNIX tools work (e.g. `chmod`) .

From now on, `sanssh` client will always treat `--mode` flag value as a 12-bit octal number.