### PR TITLE
Fix deadlock on return-early on not_found during WaitForApproval 

### DIFF
--- a/services/mpa/server/server.go
+++ b/services/mpa/server/server.go
@@ -240,10 +240,10 @@ func (s *server) WaitForApproval(ctx context.Context, in *mpa.WaitForApprovalReq
 	for {
 		s.mu.Lock()
 		act, ok := s.actions[in.Id]
+		s.mu.Unlock()
 		if !ok {
 			return nil, status.Error(codes.NotFound, "MPA request not found")
 		}
-		s.mu.Unlock()
 		select {
 		case <-act.approved:
 			return &mpa.WaitForApprovalResponse{}, nil


### PR DESCRIPTION
In the mpa flow we could end up with servers getting into "close to deadlock" state as we failed to release mutex in one of the branches of the mpa flow.