### PR TITLE
Add "exec as" feature to public package interface

### DIFF
--- a/services/exec/client/utils.go
+++ b/services/exec/client/utils.go
@@ -45,12 +45,54 @@ func ExecRemoteCommand(ctx context.Context, conn *proxy.Conn, binary string, arg
 	return result[0].Resp, nil
 }
 
-// ExecRemoteCommand is a helper function for execing a command on one or remote hosts
+// ExecRemoteCommandAs is a helper function for execing a command on a remote host as specified user
+// using a proxy.Conn. If the conn is defined for >1 targets this will return an error.
+func ExecRemoteCommandAs(ctx context.Context, conn *proxy.Conn, user string, binary string, args ...string) (*pb.ExecResponse, error) {
+	if len(conn.Targets) != 1 {
+		return nil, errors.New("ExecRemoteCommand only supports single targets")
+	}
+
+	result, err := ExecRemoteCommandManyAs(ctx, conn, user, binary, args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(result) < 1 {
+		return nil, fmt.Errorf("ExecRemoteCommand error: received empty response")
+	}
+	if result[0].Error != nil {
+		return nil, fmt.Errorf("ExecRemoteCommand error: %v", result[0].Error)
+	}
+	return result[0].Resp, nil
+}
+
+// ExecRemoteCommandMany is a helper function for execing a command on one or remote hosts
 // using a proxy.Conn.
 // `binary` refers to the absolute path of the binary file on the remote host.
 func ExecRemoteCommandMany(ctx context.Context, conn *proxy.Conn, binary string, args ...string) ([]*pb.RunManyResponse, error) {
 	c := pb.NewExecClientProxy(conn)
 	req := &pb.ExecRequest{
+		Command: binary,
+		Args:    args,
+	}
+	respChan, err := c.RunOneMany(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]*pb.RunManyResponse, len(conn.Targets))
+	for r := range respChan {
+		result[r.Index] = r
+	}
+
+	return result, nil
+}
+
+// ExecRemoteCommandManyAs is a helper function for execing a command on one or remote hosts as specified user
+// using a proxy.Conn.
+// `binary` refers to the absolute path of the binary file on the remote host.
+func ExecRemoteCommandManyAs(ctx context.Context, conn *proxy.Conn, user string, binary string, args ...string) ([]*pb.RunManyResponse, error) {
+	c := pb.NewExecClientProxy(conn)
+	req := &pb.ExecRequest{
+		User:    user,
 		Command: binary,
 		Args:    args,
 	}


### PR DESCRIPTION
Add to service public interface possibility to execute processes as specified user, it allows to run commands as specified user in case sansshell used as go module