### PR TITLE
Fix for sysinfo getKernelMessage MacOS (default) impl

### DIFF
--- a/services/sysinfo/server/sysinfo_default.go
+++ b/services/sysinfo/server/sysinfo_default.go
@@ -32,7 +32,7 @@ var getUptime = func() (time.Duration, error) {
 	return 0, status.Errorf(codes.Unimplemented, "uptime is not supported")
 }
 
-var getKernelMessages = func() ([]*pb.DmsgRecord, error) {
+var getKernelMessages = func(time.Duration, <-chan struct{}) ([]*pb.DmsgRecord, error) {
 	return nil, status.Errorf(codes.Unimplemented, "dmesg is not supported")
 }
 


### PR DESCRIPTION
This fixes a build breaking bug I introduced in last PR, only occurs on MacOS. 