### PR TITLE
Add a util function for the Raw service

### DIFF
--- a/services/raw/client/client.go
+++ b/services/raw/client/client.go
@@ -143,7 +143,8 @@ func (p *callCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		var unknownMethodErr *ErrUnknownMethod
-		if errors.As(err, &unknownMethodErr) {
+		var failedToDecodeErr *ErrFailedToDecodeInput
+		if errors.As(err, &unknownMethodErr) || errors.As(err, &failedToDecodeErr) {
 			return subcommands.ExitUsageError
 		}
 		return subcommands.ExitFailure

--- a/services/raw/client/client.go
+++ b/services/raw/client/client.go
@@ -126,7 +126,6 @@ func (p *callCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 	}
 	methodName := f.Arg(0)
 
-	fmt.Printf("Sending Request to %v\n", methodName)
 	err := SendRequest(ctx, methodName, input, state.Conn, func(resp *ProxyResponse) error {
 		if resp.Error == io.EOF {
 			// Streaming commands may return EOF

--- a/services/raw/client/client.go
+++ b/services/raw/client/client.go
@@ -20,21 +20,15 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/google/subcommands"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/reflect/protoregistry"
 
 	"github.com/Snowflake-Labs/sansshell/client"
 	"github.com/Snowflake-Labs/sansshell/services/util"
@@ -82,51 +76,6 @@ func (i *repeatedString) Set(value string) error {
 	return nil
 }
 
-// decodeExactlyOne decodes a single json message from the decoder and
-// fails if more messages are present.
-func decodeExactlyOne(decoder *json.Decoder, msg proto.Message) error {
-	var raw json.RawMessage
-	if err := decoder.Decode(&raw); err != nil {
-		return fmt.Errorf("unable to read input message: %v", err)
-	}
-	if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
-		return fmt.Errorf("unable to parse input json: %v", err)
-	}
-	if decoder.More() {
-		return fmt.Errorf("more than one input object provided for non-streaming call")
-	}
-	return nil
-}
-
-func printOutput(state *util.ExecuteState, resp *proxyResponse) {
-	if resp.Error == io.EOF {
-		// Streaming commands may return EOF
-		return
-	}
-	if resp.Error != nil {
-		fmt.Fprintf(state.Err[resp.Index], "%v\n", resp.Error)
-		return
-	}
-	prettyPrinted := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Format(resp.Resp)
-	fmt.Fprintln(state.Out[resp.Index], prettyPrinted)
-}
-
-func printAllFromStream(state *util.ExecuteState, stream streamingClientProxy) error {
-	for {
-		rs, err := stream.Recv()
-		if err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return err
-		}
-		for _, r := range rs {
-			printOutput(state, r)
-		}
-	}
-
-}
-
 type callCmd struct {
 	metadata repeatedString
 }
@@ -152,8 +101,6 @@ func (p *callCmd) SetFlags(f *flag.FlagSet) {
 
 func (p *callCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
 	state := args[0].(*util.ExecuteState)
-	proxy := genericClientProxy{state.Conn}
-
 	for _, m := range p.metadata {
 		pair := strings.SplitN(m, "=", 2)
 		if len(pair) != 2 {
@@ -164,131 +111,39 @@ func (p *callCmd) Execute(ctx context.Context, f *flag.FlagSet, args ...interfac
 		ctx = metadata.AppendToOutgoingContext(ctx, pair[0], pair[1])
 	}
 
-	var input *json.Decoder
+	var input io.Reader
 	switch f.NArg() {
 	case 0:
 		fmt.Fprintln(os.Stderr, "Please specify a method name, like /HealthCheck.HealthCheck/Ok.")
 		return subcommands.ExitUsageError
 	case 1:
-		input = json.NewDecoder(os.Stdin)
+		input = os.Stdin
 	case 2:
-		input = json.NewDecoder(strings.NewReader(f.Arg(1)))
+		input = strings.NewReader(f.Arg(1))
 	default:
 		fmt.Fprintln(os.Stderr, "Too many args provided, should be <method name> <request>")
 		return subcommands.ExitUsageError
 	}
-
-	// Find our method
 	methodName := f.Arg(0)
-	var methodDescriptor protoreflect.MethodDescriptor
-	var allMethodNames []string
-	protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
-		svcs := fd.Services()
-		for i := 0; i < svcs.Len(); i++ {
-			svc := svcs.Get(i)
-			methods := svc.Methods()
-			for i := 0; i < methods.Len(); i++ {
-				method := methods.Get(i)
-				fullName := fmt.Sprintf("/%s/%s", svc.FullName(), method.Name())
-				if fullName == methodName {
-					// We found the right one, no need to continue
-					methodDescriptor = method
-					return false
-				}
-				allMethodNames = append(allMethodNames, fullName)
-			}
+
+	fmt.Printf("Sending Request to %v\n", methodName)
+	err := SendRequest(ctx, methodName, input, state.Conn, func(resp *ProxyResponse) error {
+		if resp.Error == io.EOF {
+			// Streaming commands may return EOF
+			return nil
 		}
-		return true
+		if resp.Error != nil {
+			fmt.Fprintf(state.Err[resp.Index], "%v\n", resp.Error)
+			return nil
+		}
+		prettyPrinted := protojson.MarshalOptions{UseProtoNames: true, Multiline: true}.Format(resp.Resp)
+		fmt.Fprintln(state.Out[resp.Index], prettyPrinted)
+		return nil
 	})
-	if methodDescriptor == nil {
-		sort.Strings(allMethodNames)
-		fmt.Fprintf(os.Stderr, "Unknown method %q, known ones are %v\n", methodName, allMethodNames)
-		return subcommands.ExitUsageError
-	}
-
-	// Figure out the proto types to use for requests and responses.
-	inType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Input().FullName())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to find %v in protoregistry: %v\n", methodDescriptor.Input().FullName(), err)
-		return subcommands.ExitFailure
-	}
-	outType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Output().FullName())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to find %v in protoregistry: %v\n", methodDescriptor.Output().FullName(), err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return subcommands.ExitFailure
 	}
 
-	// Make our actual call, using different ways based on the streaming options.
-	if methodDescriptor.IsStreamingClient() {
-		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-
-		var g errgroup.Group
-
-		g.Go(func() error {
-			for input.More() {
-				var raw json.RawMessage
-				if err := input.Decode(&raw); err != nil {
-					return fmt.Errorf("unable to read input message: %v", err)
-				}
-				msg := inType.New().Interface()
-				if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
-					return fmt.Errorf("unable to parse input json: %v", err)
-				}
-				if err := stream.SendMsg(msg); err != nil {
-					return err
-				}
-			}
-			return stream.CloseSend()
-		})
-		g.Go(func() error { return printAllFromStream(state, stream) })
-		if err := g.Wait(); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-	} else if !methodDescriptor.IsStreamingClient() && methodDescriptor.IsStreamingServer() {
-		in := inType.New().Interface()
-		if err := decodeExactlyOne(input, in); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitUsageError
-		}
-
-		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-		if err := stream.SendMsg(in); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-		if err := stream.CloseSend(); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-		if err := printAllFromStream(state, stream); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-	} else {
-		// It's a unary call if neither client or server has streams.
-		in := inType.New().Interface()
-		if err := decodeExactlyOne(input, in); err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitUsageError
-		}
-		resp, err := proxy.UnaryOneMany(ctx, methodName, in, outType)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			return subcommands.ExitFailure
-		}
-		for r := range resp {
-			printOutput(state, r)
-		}
-
-	}
 	return subcommands.ExitSuccess
 }

--- a/services/raw/client/utils.go
+++ b/services/raw/client/utils.go
@@ -1,0 +1,184 @@
+/* Copyright (c) 2025 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/Snowflake-Labs/sansshell/proxy/proxy"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// decodeExactlyOne decodes a single json message from the decoder and
+// fails if more messages are present.
+func decodeExactlyOne(decoder *json.Decoder, msg proto.Message) error {
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return fmt.Errorf("unable to read input message: %v", err)
+	}
+	if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
+		return fmt.Errorf("unable to parse input json: %v", err)
+	}
+	if decoder.More() {
+		return fmt.Errorf("more than one input object provided for non-streaming call")
+	}
+	return nil
+}
+
+func processResponse(resp *ProxyResponse, responseProcessors []ResponseProcessor) error {
+	for _, processor := range responseProcessors {
+		if err := processor(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func processStreamedResponse(stream StreamingClientProxy, responseProcessors []ResponseProcessor) error {
+	for {
+		rs, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		for _, r := range rs {
+			if err := processResponse(r, responseProcessors); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+type ResponseProcessor func(*ProxyResponse) error
+
+func SendRequest(ctx context.Context, methodName string, input io.Reader, conn *proxy.Conn, responseProcessors ...ResponseProcessor) error {
+	inputDecoder := json.NewDecoder(input)
+	proxy := GenericClientProxy{conn: conn}
+	// Find our method
+	var methodDescriptor protoreflect.MethodDescriptor
+	var allMethodNames []string
+	protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		svcs := fd.Services()
+		for i := 0; i < svcs.Len(); i++ {
+			svc := svcs.Get(i)
+			methods := svc.Methods()
+			for i := 0; i < methods.Len(); i++ {
+				method := methods.Get(i)
+				fullName := fmt.Sprintf("/%s/%s", svc.FullName(), method.Name())
+				if fullName == methodName {
+					// We found the right one, no need to continue
+					methodDescriptor = method
+					return false
+				}
+				allMethodNames = append(allMethodNames, fullName)
+			}
+		}
+		return true
+	})
+	if methodDescriptor == nil {
+		sort.Strings(allMethodNames)
+		return fmt.Errorf("Unknown method %q, known ones are %v\n", methodName, allMethodNames)
+	}
+
+	// Figure out the proto types to use for requests and responses.
+	inType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Input().FullName())
+	if err != nil {
+		return fmt.Errorf("Unable to find %v in protoregistry: %v\n", methodDescriptor.Input().FullName(), err)
+	}
+	outType, err := protoregistry.GlobalTypes.FindMessageByName(methodDescriptor.Output().FullName())
+	if err != nil {
+		return fmt.Errorf("Unable to find %v in protoregistry: %v\n", methodDescriptor.Output().FullName(), err)
+	}
+
+	// Make our actual call, using different ways based on the streaming options.
+	if methodDescriptor.IsStreamingClient() {
+		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
+		if err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+
+		var g errgroup.Group
+
+		g.Go(func() error {
+			for inputDecoder.More() {
+				var raw json.RawMessage
+				if err := inputDecoder.Decode(&raw); err != nil {
+					return fmt.Errorf("unable to read input message: %v", err)
+				}
+				msg := inType.New().Interface()
+				if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
+					return fmt.Errorf("unable to parse input json: %v", err)
+				}
+				if err := stream.SendMsg(msg); err != nil {
+					return err
+				}
+			}
+			return stream.CloseSend()
+		})
+		g.Go(func() error { return processStreamedResponse(stream, responseProcessors) })
+		if err := g.Wait(); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+	} else if !methodDescriptor.IsStreamingClient() && methodDescriptor.IsStreamingServer() {
+		in := inType.New().Interface()
+		if err := decodeExactlyOne(inputDecoder, in); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+
+		stream, err := proxy.StreamingOneMany(ctx, methodName, methodDescriptor, outType)
+		if err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+		if err := stream.SendMsg(in); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+		if err := stream.CloseSend(); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+		if err := processStreamedResponse(stream, responseProcessors); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+	} else {
+		// It's a unary call if neither client or server has streams.
+		in := inType.New().Interface()
+		if err := decodeExactlyOne(inputDecoder, in); err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+		resp, err := proxy.UnaryOneMany(ctx, methodName, in, outType)
+		if err != nil {
+			return fmt.Errorf("%v\n", err)
+		}
+		for r := range resp {
+			err := processResponse(r, responseProcessors)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/services/raw/client/utils.go
+++ b/services/raw/client/utils.go
@@ -31,18 +31,26 @@ import (
 	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
+type ErrFailedToDecodeInput struct {
+	Err error
+}
+
+func (e *ErrFailedToDecodeInput) Error() string {
+	return fmt.Sprintf("failed to decode input: %v", e.Err)
+}
+
 // decodeExactlyOne decodes a single json message from the decoder and
 // fails if more messages are present.
 func decodeExactlyOne(decoder *json.Decoder, msg proto.Message) error {
 	var raw json.RawMessage
 	if err := decoder.Decode(&raw); err != nil {
-		return fmt.Errorf("unable to read input message: %v", err)
+		return &ErrFailedToDecodeInput{Err: fmt.Errorf("unable to read input message: %v", err)}
 	}
 	if err := protojson.Unmarshal([]byte(raw), msg); err != nil {
-		return fmt.Errorf("unable to parse input json: %v", err)
+		return &ErrFailedToDecodeInput{Err: fmt.Errorf("unable to parse input json: %v", err)}
 	}
 	if decoder.More() {
-		return fmt.Errorf("more than one input object provided for non-streaming call")
+		return &ErrFailedToDecodeInput{Err: fmt.Errorf("more than one input object provided for non-streaming call")}
 	}
 	return nil
 }


### PR DESCRIPTION
Extracts the `Raw` service cli client logics into a function `InvokeMethod` in util.go, so that it's reusable. 
Also exports stuffs in grpcproxy.go since they're needed for invoking the function.

`InvokeMethod` accepts `ResponseProcessor` functions to let the caller decide what to do with the response.  The reason I've decided to go with this pattern is to decouple the request execution from response handling, and allow handling streaming and unary responses more uniformly. 
If there's better ways, feel free to add suggestions!

For the CLI client, I added a response processor which simply pretty-prints the responses

Testing

Simple call
```
./sanssh  --targets localhost raw call /HealthCheck.HealthCheck/Ok '{}'     
{}
```

Dns lookup
```
 ./sanssh -v 99999 --targets localhost raw call /Dns.Lookup/Lookup '{"hostname":"www.google.com"}'
2025/02/04 17:32:38 client.go:65: sanssh: "level"=0 "msg"="loading new client cert"
2025/02/04 17:32:38 client.go:70: sanssh: "level"=0 "msg"="loaded new client cert" "error"=null
{
  "result": [
    "172.217.14.196"
  ]
}
```

Dns lookup through proxy
```
/sanssh --proxy localhost -v 99999 --targets localhost raw call /Dns.Lookup/Lookup '{"hostname":"www.google.com"}'
2025/02/04 17:34:26 client.go:65: sanssh: "level"=0 "msg"="loading new client cert"
2025/02/04 17:34:26 client.go:70: sanssh: "level"=0 "msg"="loaded new client cert" "error"=null
{
  "result": [
    "142.250.69.196"
  ]
}
```

Streaming output and using stdin
```
echo '{"command":"/bin/sh", "args":["-c", "echo hi; sleep 0.5; echo ho"]}' | ./sanssh  --proxy localhost -targets localhost raw call /Exec.Exec/StreamingRun
{
  "stdout": "aGkK"
}
{
  "stdout": "aG8K"
}
```

Bidirectional streaming
```
./sanssh --proxy localhost -v 99999 --targets localhost raw call /LocalFile.LocalFile/Stat '{"filename": "/etc/resolv.conf"} {"filename": "/etc/hosts"}'
2025/02/04 17:36:40 client.go:65: sanssh: "level"=0 "msg"="loading new client cert"
2025/02/04 17:36:40 client.go:70: sanssh: "level"=0 "msg"="loaded new client cert" "error"=null
{
  "filename": "/etc/resolv.conf",
  "size": "22",
  "mode": 134218221,
  "modtime": "2024-12-07T08:11:55Z"
}
{
  "filename": "/etc/hosts",
  "size": "265",
  "mode": 420,
  "modtime": "2025-02-04T17:29:24.190445707Z"
}
```

Bad call
```
Unknown method "/Does.Not/Exist", known ones are [/Ansible.Playbook/Run /Dns.Lookup/Lookup /Exec.Exec/Run /Exec.Exec/StreamingRun /Fdb.CLI/FDBCLI /Fdb.Conf/Delete /Fdb.Conf/Read /Fdb.Conf/Write /Fdb.FDBMove/FDBMoveDataCopy /Fdb.FDBMove/FDBMoveDataWait /Fdb.Server/FDBServer /HTTPOverRPC.HTTPOverRPC/Host /HealthCheck.HealthCheck/Ok /LocalFile.LocalFile/Copy /LocalFile.LocalFile/DataGet /LocalFile.LocalFile/DataSet /LocalFile.LocalFile/List /LocalFile.LocalFile/Mkdir /LocalFile.LocalFile/Read /LocalFile.LocalFile/Readlink /LocalFile.LocalFile/Rename /LocalFile.LocalFile/Rm /LocalFile.LocalFile/Rmdir /LocalFile.LocalFile/SetFileAttributes /LocalFile.LocalFile/Shred /LocalFile.LocalFile/Stat /LocalFile.LocalFile/Sum /LocalFile.LocalFile/Symlink /LocalFile.LocalFile/Write /Mpa.Mpa/Approve /Mpa.Mpa/Clear /Mpa.Mpa/Get /Mpa.Mpa/List /Mpa.Mpa/Store /Mpa.Mpa/WaitForApproval /Network.Network/TCPCheck /Packages.Packages/Cleanup /Packages.Packages/Install /Packages.Packages/ListInstalled /Packages.Packages/Remove /Packages.Packages/RepoList /Packages.Packages/Search /Packages.Packages/Update /Power.Power/Reboot /Process.Process/GetJavaStacks /Process.Process/GetMemoryDump /Process.Process/GetStacks /Process.Process/Kill /Process.Process/List /Proxy.Proxy/Proxy /Sansshell.Logging/GetVerbosity /Sansshell.Logging/SetVerbosity /Sansshell.State/Version /Service.Service/Action /Service.Service/List /Service.Service/Status /SysInfo.SysInfo/Dmesg /SysInfo.SysInfo/Journal /SysInfo.SysInfo/Uptime /TLSInfo.TLSInfo/GetTLSCertificate]

```