### PR TITLE
Fix bug in FDB getrange command

### DIFF
--- a/services/fdb/client/client.go
+++ b/services/fdb/client/client.go
@@ -1650,7 +1650,7 @@ func (r *fdbCLIGetrangeCmd) Execute(ctx context.Context, f *flag.FlagSet, args .
 	}
 	r.req.BeginKey = f.Arg(0)
 	switch f.NArg() {
-	case 1:
+	case 2:
 		// This could be an end key or a limit. If it parses as a integer it's a limit and there
 		// can't be anything else. Otherwise it's and end key and the next one must parse as a limit.
 		v, err := strconv.ParseInt(f.Arg(1), 10, 32)
@@ -1664,7 +1664,7 @@ func (r *fdbCLIGetrangeCmd) Execute(ctx context.Context, f *flag.FlagSet, args .
 		r.req.Limit = &wrapperspb.UInt32Value{
 			Value: uint32(v),
 		}
-	case 2:
+	case 3:
 		// 2nd one is a limit so has to be a number.
 		v, err := strconv.ParseInt(f.Arg(2), 10, 32)
 		if err != nil {


### PR DESCRIPTION
BUG: go run ./cmd/sanssh fdbcli run "getrange from_key to_key limit omits limit and to_key