### PR TITLE
SNOW-2147639: fix fdb conf command when key string has a column symbol

### DIFF
--- a/services/fdb/server/conf.go
+++ b/services/fdb/server/conf.go
@@ -47,7 +47,10 @@ var (
 )
 
 func (s *cserver) Read(_ context.Context, req *pb.ReadRequest) (*pb.FdbConfResponse, error) {
-	cfg, err := ini.Load(req.Location.File)
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		KeyValueDelimiters:      "=",
+		PreserveSurroundedQuote: true,
+	}, req.Location.File)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not load config file %s: %v", req.Location.File, err)
 	}
@@ -75,7 +78,10 @@ func (s *cserver) Write(_ context.Context, req *pb.WriteRequest) (*emptypb.Empty
 		return nil, status.Error(codes.InvalidArgument, "key value can not be empty")
 	}
 
-	cfg, err := ini.Load(req.Location.File)
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		KeyValueDelimiters:      "=",
+		PreserveSurroundedQuote: true,
+	}, req.Location.File)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not load config file %s: %v", req.Location.File, err)
 	}
@@ -95,7 +101,10 @@ func (s *cserver) Delete(_ context.Context, req *pb.DeleteRequest) (*emptypb.Emp
 		return nil, status.Error(codes.InvalidArgument, "section name can not be empty")
 	}
 
-	cfg, err := ini.Load(req.Location.File)
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		KeyValueDelimiters:      "=",
+		PreserveSurroundedQuote: true,
+	}, req.Location.File)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not load config file %s: %v", req.Location.File, err)
 	}

--- a/services/fdb/server/conf_test.go
+++ b/services/fdb/server/conf_test.go
@@ -135,9 +135,11 @@ cluster_file = /etc/foundatindb/fdb.cluster`)
 
 	client := pb.NewConfClient(conn)
 	for _, tc := range []struct {
-		name     string
-		req      *pb.WriteRequest
-		expected string
+		name            string
+		req             *pb.WriteRequest
+		expected        string
+		expectErr       bool
+		expectErrString string
 	}{
 		{
 			name: "write cluster_file to general",
@@ -168,180 +170,13 @@ test = badcoffee`,
 				Value: "badcoffee",
 			},
 		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.Write(ctx, tc.req)
-			testutil.FatalOnErr(fmt.Sprintf("%v - resp %v", tc.name, resp), err, t)
-			got, err := os.ReadFile(name)
-			testutil.FatalOnErr("failed reading config file", err, t)
-			sGot := strings.TrimSpace(string(got))
-			if sGot != tc.expected {
-				t.Errorf("expected: %q, got: %q", tc.expected, sGot)
-			}
-			// check the new file's permission and ownership
-			gotFileInfo, err := os.Stat(tc.req.Location.File)
-			testutil.FatalOnErr("can't get file stat info", err, t)
-			if gotFileInfo.Mode() != fs.FileMode(originMod) {
-				t.Errorf("expected file mode: %q, got: %q", fs.FileMode(originMod), gotFileInfo.Mode())
-			}
-			if uint32(setUID) != uint32(originUid) {
-				t.Errorf("expected file owner - user id: %d, got: %d", originUid, gotFileInfo.Sys().(*syscall.Stat_t).Uid)
-			}
-			if uint32(setGID) != uint32(originGid) {
-				t.Errorf("expected file group - group id: %d, got: %d", originGid, gotFileInfo.Sys().(*syscall.Stat_t).Gid)
-			}
-		})
-	}
-}
-
-func TestDelete(t *testing.T) {
-	temp := t.TempDir()
-	f1, err := os.CreateTemp(temp, "testfile.*")
-	testutil.FatalOnErr("can't create tmpfile", err, t)
-	_, err = f1.WriteString(`[general]
-cluster_file = /etc/foundatindb/fdb.cluster
-
-[foo.1]
-bar = baz
-
-[foo.2]
-bar = baz`)
-	testutil.FatalOnErr("WriteString", err, t)
-	name := f1.Name()
-	err = f1.Close()
-	testutil.FatalOnErr("can't close tmpfile", err, t)
-
-	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	testutil.FatalOnErr("grpc.DialContext(bufnet)", err, t)
-	t.Cleanup(func() { conn.Close() })
-
-	client := pb.NewConfClient(conn)
-	for _, tc := range []struct {
-		name            string
-		req             *pb.DeleteRequest
-		expected        string
-		expectErr       bool
-		expectErrString string
-	}{
-		{
-			name: "delete existing key",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "foo.2", Key: "bar"},
-			},
-			expected: `[general]
-cluster_file = /etc/foundatindb/fdb.cluster
-
-[foo.1]
-bar = baz
-
-[foo.2]`,
-		},
-		{
-			name: "delete empty section",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "foo.2", Key: ""},
-			},
-			expected: `[general]
-cluster_file = /etc/foundatindb/fdb.cluster
-
-[foo.1]
-bar = baz`,
-		},
-		{
-			name: "delete section that doesnt exist",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "foo.42", Key: "234"},
-			},
-			expected: `[general]
-cluster_file = /etc/foundatindb/fdb.cluster
-
-[foo.1]
-bar = baz`,
-			expectErr:       true,
-			expectErrString: "section foo.42 does not exist",
-		},
-		{
-			name: "delete whole section with keys",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "foo.1", Key: ""},
-			},
-			expected: `[general]
-cluster_file = /etc/foundatindb/fdb.cluster`,
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.Delete(ctx, tc.req)
-			if err != nil {
-				if tc.expectErr {
-					if !strings.Contains(err.Error(), tc.expectErrString) {
-						t.Fatalf("\nIncorrect error. Expected \"%v\" to contain \"%v\"", err, tc.expectErrString)
-					} else {
-						return
-					}
-				} else {
-					testutil.FatalOnErr(fmt.Sprintf("%v - resp %v", tc.name, resp), err, t)
-				}
-			}
-			got, err := os.ReadFile(name)
-			testutil.FatalOnErr("failed reading config file", err, t)
-			sGot, sExpected := strings.TrimSpace(string(got)), strings.TrimSpace(tc.expected)
-			if sGot != sExpected {
-				t.Errorf("expected: %q, got: %q", sExpected, sGot)
-			}
-		})
-	}
-}
-
-func TestWriteWithColonInKey(t *testing.T) {
-	temp := t.TempDir()
-	f1, err := os.CreateTemp(temp, "testfile.*")
-	testutil.FatalOnErr("can't create tmpfile", err, t)
-	_, err = f1.WriteString(`[general]
-cluster_file = /etc/foundationdb/fdb.cluster`)
-	testutil.FatalOnErr("WriteString", err, t)
-	name := f1.Name()
-	err = f1.Close()
-	testutil.FatalOnErr("can't close tmpfile", err, t)
-
-	// Mock chown and getUidGid functions
-	originUid, originGid, originMod := 1000, 1000, int(0775)
-
-	savedChown := chown
-	chown = func(path string, uid int, gid int) error {
-		return nil
-	}
-
-	savedGetUidGid := getUidGid
-	getUidGid = func(file fs.FileInfo) (uint32, uint32) {
-		return uint32(originUid), uint32(originGid)
-	}
-
-	if err = unix.Chmod(name, uint32(fs.FileMode(originMod).Perm())); err != nil {
-		testutil.FatalOnErr("can't change mod of the tmpfile", err, t)
-	}
-
-	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	testutil.FatalOnErr("grpc.DialContext(bufnet)", err, t)
-	t.Cleanup(func() {
-		conn.Close()
-		chown = savedChown
-		getUidGid = savedGetUidGid
-	})
-
-	client := pb.NewConfClient(conn)
-	for _, tc := range []struct {
-		name     string
-		req      *pb.WriteRequest
-		expected string
-	}{
 		{
 			name: "write key with colon in key name",
 			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
+cluster_file = /tmp/fdb.cluster
+
+[backup.1]
+test = badcoffee
 
 [backup_agent]
 the:key:with:colon = test_value`,
@@ -357,7 +192,10 @@ the:key:with:colon = test_value`,
 		{
 			name: "write key containing colon in value",
 			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
+cluster_file = /tmp/fdb.cluster
+
+[backup.1]
+test = badcoffee
 
 [backup_agent]
 the:key:with:colon = test_value
@@ -376,7 +214,10 @@ listen_address = 127.0.0.1:4500`,
 		{
 			name: "write key with multiple colons in key name",
 			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
+cluster_file = /tmp/fdb.cluster
+
+[backup.1]
+test = badcoffee
 
 [backup_agent]
 the:key:with:colon = test_value
@@ -395,66 +236,6 @@ database:connection:string:key = "connection://host:port/db"`,
 				Value: `"connection://host:port/db"`,
 			},
 		},
-		{
-			name: "write key with colon and equals in value",
-			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[backup_agent]
-the:key:with:colon = test_value
-
-[network]
-listen_address = 127.0.0.1:4500
-
-[cluster]
-database:connection:string:key = "connection://host:port/db"
-
-[advanced]
-connection:params = "timeout=30:retry=3:host=localhost"`,
-			req: &pb.WriteRequest{
-				Location: &pb.Location{
-					File:    name,
-					Section: "advanced",
-					Key:     "connection:params",
-				},
-				Value: `"timeout=30:retry=3:host=localhost"`,
-			},
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.Write(ctx, tc.req)
-			testutil.FatalOnErr(fmt.Sprintf("%v - resp %v", tc.name, resp), err, t)
-			got, err := os.ReadFile(name)
-			testutil.FatalOnErr("failed reading config file", err, t)
-			sGot := strings.TrimSpace(string(got))
-			if sGot != tc.expected {
-				t.Errorf("expected: %q, got: %q", tc.expected, sGot)
-			}
-		})
-	}
-}
-
-func TestWriteValidationErrors(t *testing.T) {
-	temp := t.TempDir()
-	f1, err := os.CreateTemp(temp, "testfile.*")
-	testutil.FatalOnErr("can't create tmpfile", err, t)
-	name := f1.Name()
-	err = f1.Close()
-	testutil.FatalOnErr("can't close tmpfile", err, t)
-
-	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	testutil.FatalOnErr("grpc.DialContext(bufnet)", err, t)
-	t.Cleanup(func() { conn.Close() })
-
-	client := pb.NewConfClient(conn)
-	for _, tc := range []struct {
-		name            string
-		req             *pb.WriteRequest
-		expectErr       bool
-		expectErrString string
-	}{
 		{
 			name: "empty section name",
 			req: &pb.WriteRequest{
@@ -497,139 +278,55 @@ func TestWriteValidationErrors(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.Write(ctx, tc.req)
-			if err == nil {
-				t.Fatal("expected error but got none")
+			resp, err := client.Write(ctx, tc.req)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tc.expectErrString) {
+					t.Errorf("expected error to contain %q, got %q", tc.expectErrString, err.Error())
+				}
+				return
 			}
-			if !strings.Contains(err.Error(), tc.expectErrString) {
-				t.Errorf("expected error to contain %q, got %q", tc.expectErrString, err.Error())
-			}
-		})
-	}
-}
-
-func TestDeleteWithColonInKey(t *testing.T) {
-	temp := t.TempDir()
-	f1, err := os.CreateTemp(temp, "testfile.*")
-	testutil.FatalOnErr("can't create tmpfile", err, t)
-	_, err = f1.WriteString(`[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[backup_agent]
-log_directory = /var/log/foundationdb
-the:key:with:colon = test_value
-backup_policy = always
-
-[network]
-listen_address = 127.0.0.1:4500
-public_address = auto
-
-[cluster]
-database:connection:string:key = "connection://host:port/db"`)
-	testutil.FatalOnErr("WriteString", err, t)
-	name := f1.Name()
-	err = f1.Close()
-	testutil.FatalOnErr("can't close tmpfile", err, t)
-
-	ctx := context.Background()
-	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	testutil.FatalOnErr("grpc.DialContext(bufnet)", err, t)
-	t.Cleanup(func() { conn.Close() })
-
-	client := pb.NewConfClient(conn)
-	for _, tc := range []struct {
-		name     string
-		req      *pb.DeleteRequest
-		expected string
-	}{
-		{
-			name: "delete key with colon in key name",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "backup_agent", Key: "the:key:with:colon"},
-			},
-			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[backup_agent]
-log_directory = /var/log/foundationdb
-backup_policy = always
-
-[network]
-listen_address = 127.0.0.1:4500
-public_address = auto
-
-[cluster]
-database:connection:string:key = "connection://host:port/db"`,
-		},
-		{
-			name: "delete key with multiple colons in key name",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "cluster", Key: "database:connection:string:key"},
-			},
-			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[backup_agent]
-log_directory = /var/log/foundationdb
-backup_policy = always
-
-[network]
-listen_address = 127.0.0.1:4500
-public_address = auto
-
-[cluster]`,
-		},
-		{
-			name: "delete key with colon in value",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "network", Key: "listen_address"},
-			},
-			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[backup_agent]
-log_directory = /var/log/foundationdb
-backup_policy = always
-
-[network]
-public_address = auto
-
-[cluster]`,
-		},
-		{
-			name: "delete entire section containing keys with colons",
-			req: &pb.DeleteRequest{
-				Location: &pb.Location{File: name, Section: "backup_agent", Key: ""},
-			},
-			expected: `[general]
-cluster_file = /etc/foundationdb/fdb.cluster
-
-[network]
-public_address = auto
-
-[cluster]`,
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.Delete(ctx, tc.req)
 			testutil.FatalOnErr(fmt.Sprintf("%v - resp %v", tc.name, resp), err, t)
 			got, err := os.ReadFile(name)
 			testutil.FatalOnErr("failed reading config file", err, t)
-			sGot, sExpected := strings.TrimSpace(string(got)), strings.TrimSpace(tc.expected)
-			if sGot != sExpected {
-				t.Errorf("expected: %q, got: %q", sExpected, sGot)
+			sGot := strings.TrimSpace(string(got))
+			if sGot != tc.expected {
+				t.Errorf("expected: %q, got: %q", tc.expected, sGot)
+			}
+			// check the new file's permission and ownership
+			gotFileInfo, err := os.Stat(tc.req.Location.File)
+			testutil.FatalOnErr("can't get file stat info", err, t)
+			if gotFileInfo.Mode() != fs.FileMode(originMod) {
+				t.Errorf("expected file mode: %q, got: %q", fs.FileMode(originMod), gotFileInfo.Mode())
+			}
+			if uint32(setUID) != uint32(originUid) {
+				t.Errorf("expected file owner - user id: %d, got: %d", originUid, gotFileInfo.Sys().(*syscall.Stat_t).Uid)
+			}
+			if uint32(setGID) != uint32(originGid) {
+				t.Errorf("expected file group - group id: %d, got: %d", originGid, gotFileInfo.Sys().(*syscall.Stat_t).Gid)
 			}
 		})
 	}
 }
 
-func TestDeleteValidationErrors(t *testing.T) {
+func TestDelete(t *testing.T) {
 	temp := t.TempDir()
 	f1, err := os.CreateTemp(temp, "testfile.*")
 	testutil.FatalOnErr("can't create tmpfile", err, t)
 	_, err = f1.WriteString(`[general]
-cluster_file = /etc/foundationdb/fdb.cluster`)
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar = baz
+the:key:with:colon = test_value
+
+[foo.2]
+bar = baz
+
+[backup_agent]
+database:connection:string:key = "connection://host:port/db"`)
 	testutil.FatalOnErr("WriteString", err, t)
 	name := f1.Name()
 	err = f1.Close()
@@ -644,9 +341,96 @@ cluster_file = /etc/foundationdb/fdb.cluster`)
 	for _, tc := range []struct {
 		name            string
 		req             *pb.DeleteRequest
+		expected        string
 		expectErr       bool
 		expectErrString string
 	}{
+		{
+			name: "delete existing key",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "foo.2", Key: "bar"},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar                = baz
+the:key:with:colon = test_value
+
+[foo.2]
+
+[backup_agent]
+database:connection:string:key = "connection://host:port/db"`,
+		},
+		{
+			name: "delete empty section",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "foo.2", Key: ""},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar                = baz
+the:key:with:colon = test_value
+
+[backup_agent]
+database:connection:string:key = "connection://host:port/db"`,
+		},
+		{
+			name: "delete section that doesnt exist",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "foo.42", Key: "234"},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar                = baz
+the:key:with:colon = test_value
+
+[backup_agent]
+database:connection:string:key = "connection://host:port/db"`,
+			expectErr:       true,
+			expectErrString: "section foo.42 does not exist",
+		},
+		{
+			name: "delete key with colon in key name",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "foo.1", Key: "the:key:with:colon"},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar = baz
+
+[backup_agent]
+database:connection:string:key = "connection://host:port/db"`,
+		},
+		{
+			name: "delete key with multiple colons in key name",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "backup_agent", Key: "database:connection:string:key"},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[foo.1]
+bar = baz
+
+[backup_agent]`,
+		},
+		{
+			name: "delete whole section with keys",
+			req: &pb.DeleteRequest{
+				Location: &pb.Location{File: name, Section: "foo.1", Key: ""},
+			},
+			expected: `[general]
+cluster_file = /etc/foundatindb/fdb.cluster
+
+[backup_agent]`,
+		},
 		{
 			name: "empty section name",
 			req: &pb.DeleteRequest{
@@ -674,12 +458,23 @@ cluster_file = /etc/foundationdb/fdb.cluster`)
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := client.Delete(ctx, tc.req)
-			if err == nil {
-				t.Fatal("expected error but got none")
+			resp, err := client.Delete(ctx, tc.req)
+			if err != nil {
+				if tc.expectErr {
+					if !strings.Contains(err.Error(), tc.expectErrString) {
+						t.Fatalf("\nIncorrect error. Expected \"%v\" to contain \"%v\"", err, tc.expectErrString)
+					} else {
+						return
+					}
+				} else {
+					testutil.FatalOnErr(fmt.Sprintf("%v - resp %v", tc.name, resp), err, t)
+				}
 			}
-			if !strings.Contains(err.Error(), tc.expectErrString) {
-				t.Errorf("expected error to contain %q, got %q", tc.expectErrString, err.Error())
+			got, err := os.ReadFile(name)
+			testutil.FatalOnErr("failed reading config file", err, t)
+			sGot, sExpected := strings.TrimSpace(string(got)), strings.TrimSpace(tc.expected)
+			if sGot != sExpected {
+				t.Errorf("expected: %q, got: %q", sExpected, sGot)
 			}
 		})
 	}

--- a/services/fdb/server/testdata/foundationdb.conf
+++ b/services/fdb/server/testdata/foundationdb.conf
@@ -22,5 +22,6 @@ restart_delay = 60
 
 [backup_agent]
 command = /usr/lib/foundationdb/backup_agent/backup_agent
+the:key:with:colon = test_value
 
 [backup_agent.1]


### PR DESCRIPTION
This PR is fixing the `fdb conf` command. The problem is that INI library is treating column `:` as a delimiter. In FDB config we have a key string which has a column and that causes big problems.

The solution is to initialize the library with only `=` symbol as a delimiter. Also we need to remove the backticks when writing the target key starting as FDB behavior  is undefined in this case.
