### PR TITLE
Add sanssh whoami cmd

### DIFF
--- a/auth/mtls/flags/flags.go
+++ b/auth/mtls/flags/flags.go
@@ -75,7 +75,7 @@ func (flagLoader) CertsRefreshed() bool {
 	return false
 }
 
-func (f flagLoader) GetClientCertInfo(ctx context.Context) (*mtls.ClientCertInfo, error) {
+func (f flagLoader) GetClientCertInfo(ctx context.Context, _ string) (*mtls.ClientCertInfo, error) {
 	cert, err := f.LoadClientCertificate(ctx)
 	if err != nil {
 		return nil, err

--- a/auth/mtls/flags/flags.go
+++ b/auth/mtls/flags/flags.go
@@ -75,6 +75,24 @@ func (flagLoader) CertsRefreshed() bool {
 	return false
 }
 
+func (f flagLoader) GetClientCertInfo(ctx context.Context) (*mtls.ClientCertInfo, error) {
+	cert, err := f.LoadClientCertificate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, err
+	}
+	return &mtls.ClientCertInfo{
+		Username:   x509Cert.Subject.CommonName,
+		CertIssuer: x509Cert.Issuer.CommonName,
+		ValidUntil: x509Cert.NotAfter,
+		Groups:     x509Cert.Subject.OrganizationalUnit,
+	}, nil
+}
+
 func init() {
 	if err := mtls.Register(loaderName, flagLoader{}); err != nil {
 		panic(err)

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/Snowflake-Labs/sansshell/telemetry/metrics"
 	"github.com/go-logr/logr"
@@ -46,6 +47,14 @@ var (
 	loaderMu sync.RWMutex
 	loaders  = make(map[string]CredentialsLoader)
 )
+
+// ClientCertInfo contains certificate-based user information
+type ClientCertInfo struct {
+	Username   string
+	CertIssuer string
+	ValidUntil time.Time
+	Groups     []string
+}
 
 // A CredentialsLoader loads mTLS credential data.
 type CredentialsLoader interface {
@@ -76,6 +85,10 @@ type CredentialsLoader interface {
 	// implementation to support but allows for dynamic refresh of certificates
 	// without a server restart.
 	CertsRefreshed() bool
+
+	// GetClientCertInfo extracts client certificate information from the client certificate
+	// and other sources, depending on the Certificate Loader type.
+	GetClientCertInfo(context.Context) (*ClientCertInfo, error)
 }
 
 // WrappedTransportCredentials wraps a credentials.TransportCredentials and

--- a/auth/mtls/mtls.go
+++ b/auth/mtls/mtls.go
@@ -88,7 +88,7 @@ type CredentialsLoader interface {
 
 	// GetClientCertInfo extracts client certificate information from the client certificate
 	// and other sources, depending on the Certificate Loader type.
-	GetClientCertInfo(context.Context) (*ClientCertInfo, error)
+	GetClientCertInfo(context.Context, string) (*ClientCertInfo, error)
 }
 
 // WrappedTransportCredentials wraps a credentials.TransportCredentials and

--- a/auth/mtls/mtls_test.go
+++ b/auth/mtls/mtls_test.go
@@ -159,6 +159,10 @@ func (s *simpleLoader) CertsRefreshed() bool {
 	return s.name == "refresh"
 }
 
+func (s *simpleLoader) GetClientCertInfo(context.Context, string) (*ClientCertInfo, error) {
+	return nil, nil
+}
+
 func serverWithPolicy(t *testing.T, policy string) (*bufconn.Listener, *grpc.Server) {
 	t.Helper()
 	err := Register("refresh", &simpleLoader{name: "refresh"})

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -189,7 +189,7 @@ func Run(ctx context.Context, rs RunState) {
 			cmd := &client.WhoamiCommand{}
 			ctx := context.Background()
 			fs := flag.NewFlagSet("whoami", flag.ExitOnError)
-			os.Exit(int(cmd.Execute(ctx, fs, rs.CredSource)))
+			os.Exit(int(cmd.Execute(ctx, fs, client.WhoamiParams{CredSource: rs.CredSource, ProxyHost: rs.Proxy})))
 		}
 	}
 	if len(flag.Args()) <= 1 {

--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -175,10 +175,9 @@ func (t *clientStreamWithTimeout) RecvMsg(m interface{}) error {
 func Run(ctx context.Context, rs RunState) {
 	// If we're running internal commands we don't need anything else.
 	for i, f := range flag.Args() {
-		// Only do this if it's in the first couple positions. (up to 2nd position)
-		// Otherwise we end up doing - sanssh service enable help
-		// which then tries to actually run the enable command without
-		// a conn and blows up.
+		// Omits unneeded part of the setup for internal commands, but only when they're passed as arguments in the beginning of the command (up to 2nd position).
+		// This prevents us from parsing e.g. user input `sanssh service enable help` as `sanssh help` and running `enable` command without
+		// the proper setup (e.g. a valid connection to sansshell-server), resulting in an error.
 		if i > 1 {
 			break
 		}

--- a/services/whoami/client/client.go
+++ b/services/whoami/client/client.go
@@ -1,0 +1,79 @@
+/* Copyright (c) 2025 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"crypto/x509"
+	"flag"
+	"fmt"
+
+	"github.com/Snowflake-Labs/sansshell/auth/mtls"
+	"github.com/go-logr/logr"
+	"github.com/google/subcommands"
+)
+
+const (
+	CredSourceFlags = "flags"
+)
+
+type WhoamiCommand struct{}
+
+func (w *WhoamiCommand) Name() string             { return "whoami" }
+func (w *WhoamiCommand) Synopsis() string         { return "Prints the current user and its groups" }
+func (w *WhoamiCommand) Usage() string            { return "whoami\n" }
+func (w *WhoamiCommand) SetFlags(f *flag.FlagSet) {}
+
+func (w *WhoamiCommand) Execute(ctx context.Context, _ *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	// Extract the credential source from args if provided
+	var credSource string
+	if len(args) > 0 {
+		if v, ok := args[0].(string); ok {
+			credSource = v
+		}
+	}
+
+	if credSource == CredSourceFlags {
+		logger.Info("loading new client cert from source", credSource)
+		loader, err := mtls.Loader(credSource)
+		if err != nil {
+			fmt.Printf("failed to load corresponding certificate loader %v\n", err)
+			return subcommands.ExitFailure
+		}
+
+		cert, err := loader.LoadClientCertificate(ctx)
+		if err != nil {
+			fmt.Printf("failed to load client certificate from %q: %v\n", credSource, err)
+			return subcommands.ExitFailure
+		}
+
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			fmt.Printf("failed to parse certificate: %v", err)
+			return subcommands.ExitFailure
+		}
+
+		ShowClientInfoFromCert(x509Cert)
+		showGroupsFromCert(x509Cert)
+		return subcommands.ExitSuccess
+	} else {
+		fmt.Printf("Unsupported credential source: %s\n", credSource)
+		return subcommands.ExitFailure
+	}
+}

--- a/services/whoami/client/utils.go
+++ b/services/whoami/client/utils.go
@@ -17,9 +17,10 @@ Copyright (c) 2025 Snowflake Inc. All rights reserved.
 package client
 
 import (
-	"crypto/x509"
 	"fmt"
 	"time"
+
+	"github.com/Snowflake-Labs/sansshell/auth/mtls"
 )
 
 func roundRemainingTime(t time.Time) (int, int, int) {
@@ -30,21 +31,18 @@ func roundRemainingTime(t time.Time) (int, int, int) {
 	return days, hours, minutes
 }
 
-func ShowClientInfoFromCert(x509Cert *x509.Certificate) {
-	fmt.Println("username:", x509Cert.Subject.CommonName)
+func showClientInfoFromClientCertInfo(certInfo mtls.ClientCertInfo) {
+	fmt.Println("username:", certInfo.Username)
 	fmt.Println("cert:")
-	fmt.Println("\tissuer:", x509Cert.Issuer.CommonName)
-	days, hours, minutes := roundRemainingTime(x509Cert.NotAfter)
+	fmt.Println("\tissuer:", certInfo.CertIssuer)
+	days, hours, minutes := roundRemainingTime(certInfo.ValidUntil)
 	if days < 0 || hours < 0 || minutes < 0 {
-		fmt.Printf("\tvalid until: %v (expired)\n", x509Cert.NotAfter)
+		fmt.Printf("\tvalid until: %v (expired)\n", certInfo.ValidUntil)
 	} else {
-		fmt.Printf("\tvalid until: %v (%d days %d hours %d minutes)\n", x509Cert.NotAfter, days, hours, minutes)
+		fmt.Printf("\tvalid until: %v (%d days %d hours %d minutes)\n", certInfo.ValidUntil, days, hours, minutes)
 	}
-}
-
-func showGroupsFromCert(x509Cert *x509.Certificate) {
 	fmt.Println("groups:")
-	for _, group := range x509Cert.Subject.OrganizationalUnit {
+	for _, group := range certInfo.Groups {
 		fmt.Println("\t", group)
 	}
 }

--- a/services/whoami/client/utils.go
+++ b/services/whoami/client/utils.go
@@ -1,19 +1,19 @@
-/*
-Copyright (c) 2025 Snowflake Inc. All rights reserved.
+/* Copyright (c) 2025 Snowflake Inc. All rights reserved.
 
-	Licensed under the Apache License, Version 2.0 (the
-	"License"); you may not use this file except in compliance
-	with the License.  You may obtain a copy of the License at
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
 
-	  http://www.apache.org/licenses/LICENSE-2.0
+     http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing,
-	software distributed under the License is distributed on an
-	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-	KIND, either express or implied.  See the License for the
-	specific language governing permissions and limitations
-	under the License.
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
 */
+
 package client
 
 import (

--- a/services/whoami/client/utils.go
+++ b/services/whoami/client/utils.go
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2025 Snowflake Inc. All rights reserved.
+
+	Licensed under the Apache License, Version 2.0 (the
+	"License"); you may not use this file except in compliance
+	with the License.  You may obtain a copy of the License at
+
+	  http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing,
+	software distributed under the License is distributed on an
+	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+	KIND, either express or implied.  See the License for the
+	specific language governing permissions and limitations
+	under the License.
+*/
+package client
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+)
+
+func roundRemainingTime(t time.Time) (int, int, int) {
+	remaining := time.Until(t).Round(time.Minute)
+	days := int(remaining.Hours()) / 24
+	hours := int(remaining.Hours()) % 24
+	minutes := int(remaining.Minutes()) % 60
+	return days, hours, minutes
+}
+
+func ShowClientInfoFromCert(x509Cert *x509.Certificate) {
+	fmt.Println("username:", x509Cert.Subject.CommonName)
+	fmt.Println("cert:")
+	fmt.Println("\tissuer:", x509Cert.Issuer.CommonName)
+	days, hours, minutes := roundRemainingTime(x509Cert.NotAfter)
+	if days < 0 || hours < 0 || minutes < 0 {
+		fmt.Printf("\tvalid until: %v (expired)\n", x509Cert.NotAfter)
+	} else {
+		fmt.Printf("\tvalid until: %v (%d days %d hours %d minutes)\n", x509Cert.NotAfter, days, hours, minutes)
+	}
+}
+
+func showGroupsFromCert(x509Cert *x509.Certificate) {
+	fmt.Println("groups:")
+	for _, group := range x509Cert.Subject.OrganizationalUnit {
+		fmt.Println("\t", group)
+	}
+}

--- a/services/whoami/client/utils_test.go
+++ b/services/whoami/client/utils_test.go
@@ -1,0 +1,71 @@
+/* Copyright (c) 2025 Snowflake Inc. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+*/
+
+package client
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRoundRemainingTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		future   time.Time
+		wantDays int
+		wantHrs  int
+		wantMins int
+	}{
+		{
+			name:     "1 day",
+			future:   time.Now().Add(24 * time.Hour),
+			wantDays: 1,
+			wantHrs:  0,
+			wantMins: 0,
+		},
+		{
+			name:     "2 day 3 hours 30 minutes",
+			future:   time.Now().Add(51*time.Hour + 30*time.Minute),
+			wantDays: 2,
+			wantHrs:  3,
+			wantMins: 30,
+		},
+		{
+			name:     "45 minutes",
+			future:   time.Now().Add(45 * time.Minute),
+			wantDays: 0,
+			wantHrs:  0,
+			wantMins: 45,
+		},
+		{
+			name:     "1 hour 45 minutes ago",
+			future:   time.Now().Add(-(1*time.Hour + 45*time.Minute)),
+			wantDays: 0,
+			wantHrs:  -1,
+			wantMins: -45,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			days, hours, minutes := roundRemainingTime(tt.future)
+			if days != tt.wantDays || hours != tt.wantHrs || minutes != tt.wantMins {
+				t.Errorf("roundRemainingTime() = (%d, %d, %d), want (%d, %d, %d)",
+					days, hours, minutes, tt.wantDays, tt.wantHrs, tt.wantMins)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a new  `whoami` command within `sanssh` CLI.

This functionality allows users to print their identity details of the current credential source.

Example usage:
`sanssh whoami
`



Example output:
```
username: sanssh
cert:
        issuer: 
        valid until: 2033-10-16 10:19:03 +0000 UTC (2997 days 16 hours 50 minutes)
groups:
         group1
         group2
```


