### PR TITLE
SNOW-2249369: fix: remove trailing spaces for ip address string in target files

### DIFF
--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -167,7 +167,16 @@ func main() {
 		defer f.Close()
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
-			*targetsFlag.Target = append(*targetsFlag.Target, scanner.Text())
+			line := scanner.Text()
+			target := strings.TrimSpace(line)
+			// Warn if whitespace was trimmed to help users clean up their files
+			if len(target) != len(line) && target != "" {
+				log.Printf("Warning: trimmed whitespace from target %q in %s", line, *targetsFile)
+			}
+			// Skip empty lines (including lines with only whitespace)
+			if target != "" {
+				*targetsFlag.Target = append(*targetsFlag.Target, target)
+			}
 		}
 		if err := scanner.Err(); err != nil {
 			log.Fatalf("scanning error reading %s: %v", *targetsFile, err)

--- a/services/util/util.go
+++ b/services/util/util.go
@@ -21,8 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	writerUtils "github.com/Snowflake-Labs/sansshell/services/util/writer"
-	"golang.org/x/term"
 	"io"
 	"os"
 	"os/exec"
@@ -30,6 +28,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	writerUtils "github.com/Snowflake-Labs/sansshell/services/util/writer"
+	"golang.org/x/term"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
@@ -370,8 +371,12 @@ func (s *StringSliceCommaOrWhitespaceFlag) Set(val string) error {
 		s.Target = new([]string)
 	}
 	for _, vals := range strings.Fields(val) {
-
-		*s.Target = append(*s.Target, strings.Split(vals, ",")...)
+		for _, target := range strings.Split(vals, ",") {
+			trimmed := strings.TrimSpace(target)
+			if trimmed != "" {
+				*s.Target = append(*s.Target, trimmed)
+			}
+		}
 	}
 	return nil
 }

--- a/services/util/util_test.go
+++ b/services/util/util_test.go
@@ -330,6 +330,36 @@ baz`,
 			wantTarget: []string{"foo", "bar", "baz"},
 			wantString: "foo,bar,baz",
 		},
+		{
+			desc:       "trailing spaces in comma separated",
+			input:      "foo , bar  , baz   ",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "trailing spaces in space separated",
+			input:      "foo   bar   baz   ",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "leading and trailing spaces",
+			input:      "  foo  ,  bar  ,  baz  ",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "tabs and multiple spaces",
+			input:      "foo\t,\tbar\t\t,\tbaz\t",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
+		{
+			desc:       "empty strings are filtered out",
+			input:      "foo, , bar,  , baz",
+			wantTarget: []string{"foo", "bar", "baz"},
+			wantString: "foo,bar,baz",
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			var flag StringSliceCommaOrWhitespaceFlag


### PR DESCRIPTION
previously the trailing space in targets-file was causing error connecting to targets. The error was pretty cryptic like `rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp: lookup 10.141.4.11 : no such host"`
