### PR TITLE
Improve healthcheck command to inform about connectivity statuses for both proxy and server

### DIFF
--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -220,7 +220,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 		if err != nil {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)
-			return err
+			return fmt.Errorf("could not connect to target from the proxy: %w", err)
 		}
 
 		// We've successfully connected and can replace the initial unconnected stream

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -213,7 +213,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)
 			s.cancelFunc()
-			return fmt.Errorf("Proxy-target[%s] connection cannot be established: %w", s.Target(), err)
+			return fmt.Errorf("Proxy-target connection cannot be established: %w", err)
 		}
 		s.grpcConn = grpcConn
 		grpcStream, err := s.grpcConn.NewStream(ctx, s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
@@ -237,7 +237,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				}
 				if err != nil {
 					s.CloseWith(err)
-					return fmt.Errorf("Proxy-target[%s] message recv failed: %w", s.Target(), err)
+					return fmt.Errorf("Proxy-target message recv failed: %w", err)
 				}
 				// otherwise, this is a streamData reply
 				packed, err := anypb.New(msg)

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -213,7 +213,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)
 			s.cancelFunc()
-			return fmt.Errorf("Could not connected to target from the proxy: %w", err)
+			return fmt.Errorf("could not connect to target from the proxy: %w", err)
 		}
 		s.grpcConn = grpcConn
 		grpcStream, err := s.grpcConn.NewStream(ctx, s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
@@ -237,7 +237,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				}
 				if err != nil {
 					s.CloseWith(err)
-					return fmt.Errorf("Proxy could not receive response from the target: %w", err)
+					return fmt.Errorf("proxy could not receive response from the target: %w", err)
 				}
 				// otherwise, this is a streamData reply
 				packed, err := anypb.New(msg)

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -213,7 +213,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)
 			s.cancelFunc()
-			return fmt.Errorf("Proxy-target connection cannot be established: %w", err)
+			return fmt.Errorf("Could not connected to target from the proxy: %w", err)
 		}
 		s.grpcConn = grpcConn
 		grpcStream, err := s.grpcConn.NewStream(ctx, s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
@@ -237,7 +237,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				}
 				if err != nil {
 					s.CloseWith(err)
-					return fmt.Errorf("Proxy-target message recv failed: %w", err)
+					return fmt.Errorf("Proxy could not receive response from the target: %w", err)
 				}
 				// otherwise, this is a streamData reply
 				packed, err := anypb.New(msg)
@@ -330,7 +330,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			// by the errgroup, and sent in the ServerClose
 			if err != nil {
 				s.cancelFunc()
-				return err
+				return fmt.Errorf("Proxy could not send request to target: %w", err)
 			}
 			// no error. If client streaming is not expected, then we're
 			// done

--- a/proxy/server/target.go
+++ b/proxy/server/target.go
@@ -213,7 +213,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 			// We cannot create a new stream to the target. So we need to cancel this stream.
 			s.logger.Info("unable to create stream", "status", err)
 			s.cancelFunc()
-			return err
+			return fmt.Errorf("Proxy-target[%s] connection cannot be established: %w", s.Target(), err)
 		}
 		s.grpcConn = grpcConn
 		grpcStream, err := s.grpcConn.NewStream(ctx, s.serviceMethod.StreamDesc(), s.serviceMethod.FullName())
@@ -237,7 +237,7 @@ func (s *TargetStream) Run(nonce uint32, replyChan chan *pb.ProxyReply) {
 				}
 				if err != nil {
 					s.CloseWith(err)
-					return err
+					return fmt.Errorf("Proxy-target[%s] message recv failed: %w", s.Target(), err)
 				}
 				// otherwise, this is a streamData reply
 				packed, err := anypb.New(msg)


### PR DESCRIPTION
To improve troubleshooting I decorated connectivity errors between proxy and target. It is a little bit messy, but shows more explicitly that error is related to latter connection stage.
It cannot be done better (at least I think so) because of error handling design. We want service creators to handle errors and at the same time services cannot distinghuish between proxy and non-proxy connectivity (by design).
To improve this solution custom error structure should be sent between nodes on the protocol layer and service will still only receive well formatted string (golang err) to handle.