### PR TITLE
allow proxy authority override

### DIFF
--- a/cmd/sanssh/client/client.go
+++ b/cmd/sanssh/client/client.go
@@ -54,7 +54,8 @@ func init() {
 // to run a sansssh command.
 type RunState struct {
 	// Proxy is an optional proxy server to route requests.
-	Proxy string
+	Proxy                  string
+	ProxyAuthorityOverride string
 	// Targets is a list of remote targets to use when a proxy
 	// is in use. For non proxy must be 1 entry.
 	Targets []string
@@ -283,6 +284,10 @@ func Run(ctx context.Context, rs RunState) {
 		grpc.WithTransportCredentials(creds),
 		// Use 16MB instead of the default 4MB to allow larger responses
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(16 * 1024 * 1024)),
+	}
+
+	if rs.Proxy != "" && rs.ProxyAuthorityOverride != "" {
+		ops = append(ops, grpc.WithAuthority(rs.ProxyAuthorityOverride))
 	}
 
 	if rs.PerRPCCredentials != nil {

--- a/cmd/sanssh/main.go
+++ b/cmd/sanssh/main.go
@@ -75,6 +75,7 @@ var (
 %s in the environment can also be set instead of setting this flag. The flag will take precedence.
 If blank a direct connection to the first entry in --targets will be made.
 If port is blank the default of %d will be used`, proxyEnv, defaultProxyPort))
+	proxyAuthorityOverride = flag.String("proxy-authority-override", "", "Authority override to use when dialing the proxy (passed to grpc.WithAuthority when set)")
 	// Deprecated: --timeout flag is deprecated. Use --idle-timeout or --dial-timeout instead
 	_                = flag.Duration("timeout", defaultDialTimeout, "DEPRECATED. Please use --idle-timeout or --dial-timeout instead")
 	dialTimeout      = flag.Duration("dial-timeout", defaultDialTimeout, "How long to wait for the connection to be accepted. Timeout specified in --targets or --proxy will take precedence")
@@ -209,17 +210,18 @@ func main() {
 	}
 
 	rs := client.RunState{
-		Proxy:             *proxyAddr,
-		Targets:           *targetsFlag.Target,
-		Outputs:           *outputsFlag.Target,
-		AuthzDryRun:       *authzDryRun,
-		OutputsDir:        *outputsDir,
-		CredSource:        *credSource,
-		IdleTimeout:       *idleTimeout,
-		ClientAuthzPolicy: clientPolicy,
-		PrefixOutput:      *prefixHeader,
-		BatchSize:         *batchSize,
-		EnableMPA:         *mpa,
+		Proxy:                  *proxyAddr,
+		ProxyAuthorityOverride: *proxyAuthorityOverride,
+		Targets:                *targetsFlag.Target,
+		Outputs:                *outputsFlag.Target,
+		AuthzDryRun:            *authzDryRun,
+		OutputsDir:             *outputsDir,
+		CredSource:             *credSource,
+		IdleTimeout:            *idleTimeout,
+		ClientAuthzPolicy:      clientPolicy,
+		PrefixOutput:           *prefixHeader,
+		BatchSize:              *batchSize,
+		EnableMPA:              *mpa,
 	}
 
 	if *justification != "" {


### PR DESCRIPTION
There are cases where the proxy cert names doesn't match the hostname client uses to reach them (due to, say, internal vs external network path diffs)