### PR TITLE
auth/opa: add WithStore option and fix concurrent print-buffer race

### DIFF
--- a/auth/opa/opa.go
+++ b/auth/opa/opa.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
 )
 
@@ -53,12 +54,12 @@ var (
 type opaAuthzPolicy struct {
 	query            rego.PreparedEvalQuery
 	denialHintsQuery *rego.PreparedEvalQuery
-	b                *bytes.Buffer
 }
 
 type policyOptions struct {
 	query            string
 	denialHintsQuery string
+	store            storage.Store
 }
 
 // An Option controls the behavior of an opaAuthzPolicy
@@ -100,6 +101,24 @@ func WithDenialHintsQuery(query string) Option {
 	})
 }
 
+// WithStore returns an option that exposes the contents of `store` to the policy
+// as the `data` document during evaluation. This allows a single policy file to
+// be parameterized with external configuration instead of hard-coding values,
+// for example:
+//
+//	store := inmem.NewFromObject(map[string]any{
+//		"config": map[string]any{"allowed_method": "/Foo.Bar/Baz"},
+//	})
+//	p, _ := opa.NewOpaAuthzPolicy(ctx, policy, opa.WithStore(store))
+//
+// and a policy that references data.config.allowed_method. The same store is
+// used for both the allow query and the denial-hints query.
+func WithStore(store storage.Store) Option {
+	return optionFunc(func(o *policyOptions) {
+		o.store = store
+	})
+}
+
 // NewOpaAuthzPolicy creates a new opaAuthzPolicy by parsing the policy given
 // in the string `policy`.
 // It returns an error if the policy cannot be parsed, or does not use
@@ -121,25 +140,29 @@ func NewOpaAuthzPolicy(ctx context.Context, policy string, opts ...Option) (rpca
 		return nil, fmt.Errorf("policy has invalid package '%s' (must be '%s')", module.Package, sansshellPackage)
 	}
 
-	b := &bytes.Buffer{}
-	r := rego.New(
+	allowArgs := []func(*rego.Rego){
 		rego.Query(options.query),
 		rego.ParsedModule(module),
 		rego.EnablePrintStatements(true),
-		rego.PrintHook(topdown.NewPrintHook(b)),
-	)
+	}
+	if options.store != nil {
+		allowArgs = append(allowArgs, rego.Store(options.store))
+	}
 
-	prepared, err := r.PrepareForEval(ctx)
+	prepared, err := rego.New(allowArgs...).PrepareForEval(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("rego: PrepareForEval() error: %w", err)
 	}
 	var denialHintsQuery *rego.PreparedEvalQuery
 	if options.denialHintsQuery != "" {
-		r := rego.New(
+		hintArgs := []func(*rego.Rego){
 			rego.Query(options.denialHintsQuery),
 			rego.ParsedModule(module),
-		)
-		hints, err := r.PrepareForEval(ctx)
+		}
+		if options.store != nil {
+			hintArgs = append(hintArgs, rego.Store(options.store))
+		}
+		hints, err := rego.New(hintArgs...).PrepareForEval(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("rego: denial hints PrepareForEval() error: %w", err)
 		}
@@ -148,7 +171,6 @@ func NewOpaAuthzPolicy(ctx context.Context, policy string, opts ...Option) (rpca
 	return &opaAuthzPolicy{
 		query:            prepared,
 		denialHintsQuery: denialHintsQuery,
-		b:                b,
 	}, nil
 }
 
@@ -165,12 +187,16 @@ func (q *opaAuthzPolicy) Eval(ctx context.Context, input *rpcauth.RPCAuthInput) 
 		evalInput = rego.EvalInput(input)
 	}
 
-	results, err := q.query.Eval(ctx, evalInput)
+	// Use a per-evaluation print buffer so concurrent calls to Eval don't race
+	// on shared state and one caller's print output can't leak into another's
+	// logs.
+	var printBuf bytes.Buffer
+	results, err := q.query.Eval(ctx, evalInput, rego.EvalPrintHook(topdown.NewPrintHook(&printBuf)))
 	if err != nil {
 		return false, fmt.Errorf("authz policy evaluation error: %w", err)
 	}
-	if q.b.Len() > 0 {
-		logger.V(1).Info("print statements", "buffer", q.b.String())
+	if printBuf.Len() > 0 {
+		logger.V(1).Info("print statements", "buffer", printBuf.String())
 	}
 	return results.Allowed(), nil
 }

--- a/auth/opa/opa_test.go
+++ b/auth/opa/opa_test.go
@@ -19,12 +19,15 @@ package opa
 import (
 	"context"
 	"encoding/json"
-	"github.com/Snowflake-Labs/sansshell/auth/rpcauth"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/Snowflake-Labs/sansshell/auth/rpcauth"
+
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage/inmem"
 
 	"github.com/Snowflake-Labs/sansshell/testing/testutil"
 )
@@ -289,6 +292,80 @@ denial_hints[msg] {
 			}
 		})
 	}
+}
+
+func TestAuthzPolicyWithStore(t *testing.T) {
+	policyString := `
+package sansshell.authz
+
+default allow = false
+
+allow {
+  input.method == data.config.allowed_method
+}
+
+denial_hints[msg] {
+  not allow
+  msg := sprintf("only %s is allowed", [data.config.allowed_method])
+}
+`
+	ctx := context.Background()
+	store := inmem.NewFromObject(map[string]any{
+		"config": map[string]any{"allowed_method": "/Foo.Bar/Baz"},
+	})
+	policy, err := NewOpaAuthzPolicy(ctx, policyString,
+		WithStore(store),
+		WithDenialHintsQuery("data.sansshell.authz.denial_hints"))
+	testutil.FatalOnErr("NewOpaAuthzPolicy", err, t)
+
+	allowed, err := policy.Eval(ctx, &rpcauth.RPCAuthInput{Method: "/Foo.Bar/Baz"})
+	testutil.FatalOnErr("Eval matching", err, t)
+	if !allowed {
+		t.Errorf("Eval() with method matching data.config = false, want true")
+	}
+
+	allowed, err = policy.Eval(ctx, &rpcauth.RPCAuthInput{Method: "/Other/Method"})
+	testutil.FatalOnErr("Eval non-matching", err, t)
+	if allowed {
+		t.Errorf("Eval() with method not matching data.config = true, want false")
+	}
+
+	hints, err := policy.DenialHints(ctx, &rpcauth.RPCAuthInput{Method: "/Other/Method"})
+	testutil.FatalOnErr("DenialHints", err, t)
+	want := []string{"only /Foo.Bar/Baz is allowed"}
+	if !reflect.DeepEqual(hints, want) {
+		t.Errorf("DenialHints() = %v, want %v", hints, want)
+	}
+}
+
+// TestAuthzPolicyConcurrentEval exercises Eval from many goroutines on a policy
+// that emits print output. It is primarily meaningful under the race detector,
+// where it guards against shared mutable state in the policy across evaluations.
+func TestAuthzPolicyConcurrentEval(t *testing.T) {
+	policyString := `
+package sansshell.authz
+
+allow {
+  print("evaluating method", input.method)
+  input.method == "foo/bar"
+}
+`
+	ctx := context.Background()
+	policy, err := NewOpaAuthzPolicy(ctx, policyString)
+	testutil.FatalOnErr("NewOpaAuthzPolicy", err, t)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := policy.Eval(ctx, &rpcauth.RPCAuthInput{Method: "foo/bar"}); err != nil {
+				t.Errorf("Eval() error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func TestNewWithPolicy(t *testing.T) {


### PR DESCRIPTION
Add a WithStore option to NewOpaAuthzPolicy so a policy can be parameterized through the `data` document (for example data.config) instead of hard-coding values in the policy file. The supplied store is applied to both the allow query and the denial-hints query.

Also fix a data race: opaAuthzPolicy shared a single bytes.Buffer for rego print output across all evaluations, and that buffer is written concurrently whenever Eval is called from multiple goroutines (the normal case for a gRPC server). Each Eval now uses its own buffer, supplied per call via rego.EvalPrintHook.