### PR TITLE
Set SO_REUSEADDR for source port binding

### DIFF
--- a/services/network/README.md
+++ b/services/network/README.md
@@ -18,9 +18,7 @@ Where:
 - `<timeout>` timeout in seconds to wait for the connection to be established. Default is 3 seconds.
 - `<source-port>` local source port to bind for the outgoing TCP connection (1-65535). If unset, the OS
   chooses an ephemeral port. Binding privileged ports (`< 1024`) requires the sansshell-server process
-  to have the necessary host privilege (e.g. root or `CAP_NET_BIND_SERVICE`). Note: after a successful
-  check the OS keeps the port in `TIME_WAIT` for ~60s; repeating the check with the same `--source-port`
-  within that window will fail with "source port already in use".
+  to have the necessary host privilege (e.g. root or `CAP_NET_BIND_SERVICE`).
 
 # Useful docs
 - [service-architecture](../../docs/services-architecture.md)

--- a/services/network/client/infrastructure/input/tcp-check.controller.go
+++ b/services/network/client/infrastructure/input/tcp-check.controller.go
@@ -47,7 +47,7 @@ func (*TCPCheckCmd) Usage() string {
 
 func (p *TCPCheckCmd) SetFlags(f *flag.FlagSet) {
 	f.UintVar(&p.timeout, "timeout", 3, "Timeout in seconds to wait for response from --host on remote machine")
-	f.UintVar(&p.sourcePort, "source-port", 0, "Local source port to bind (1-65535). 0 or unset means the OS chooses an ephemeral port. Note: after a successful check, the OS holds the port in TIME_WAIT for ~60s; repeated checks with the same port within that window will fail with 'source port already in use'.")
+	f.UintVar(&p.sourcePort, "source-port", 0, "Local source port to bind (1-65535). 0 or unset means the OS chooses an ephemeral port.")
 }
 
 // Execute is a method handle command execution. It adapter between cli and business logic

--- a/services/network/server/infrastructure/output/tcp.client.go
+++ b/services/network/server/infrastructure/output/tcp.client.go
@@ -41,7 +41,21 @@ func (p *TCPClient) CheckConnectivity(ctx context.Context, hostname string, port
 	dialer := net.Dialer{Timeout: timeout}
 	if sourcePort != 0 {
 		// Bind the outgoing connection to the requested local source port.
+		// SO_REUSEADDR allows reuse of a port still in TIME_WAIT from a previous check.
 		dialer.LocalAddr = &net.TCPAddr{Port: int(sourcePort)}
+		dialer.Control = func(network, address string, c syscall.RawConn) error {
+			var setSockOptErr error
+			err := c.Control(func(fd uintptr) {
+				setSockOptErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to acquire socket fd for SO_REUSEADDR: %s", err.Error())
+			}
+			if setSockOptErr != nil {
+				return fmt.Errorf("failed to set SO_REUSEADDR: %s", setSockOptErr.Error())
+			}
+			return nil
+		}
 	}
 	conn, err := dialer.DialContext(ctx, "tcp", hostToCheck)
 	if err != nil {

--- a/services/network/server/infrastructure/output/tcp.client_integration_test.go
+++ b/services/network/server/infrastructure/output/tcp.client_integration_test.go
@@ -136,6 +136,43 @@ func TestIntegrationTCPClient_CheckConnectivity(t *testing.T) {
 		}
 	})
 
+	t.Run("It should succeed on repeated checks with the same source port due to SO_REUSEADDR", func(t *testing.T) {
+		// ARRANGE
+		// Reserve an ephemeral port then release it so we have a known free source port.
+		tmp, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Failed to find a free source port: %s", err.Error())
+		}
+		sourcePort := uint32(tmp.Addr().(*net.TCPAddr).Port)
+		tmp.Close()
+
+		client := &TCPClient{}
+
+		// ACT — first check
+		result, err := client.CheckConnectivity(context.Background(), localhost, uint32(port), 1*time.Second, sourcePort)
+
+		// ASSERT
+		if err != nil {
+			t.Fatalf("Unexpected error on first check: %s", err.Error())
+		}
+		if !result.IsOk {
+			t.Fatalf("Expected first check to succeed, got fail reason: %s", result.FailReason)
+		}
+
+		// ACT — second check immediately after, same source port.
+		// Without SO_REUSEADDR the port would linger in TIME_WAIT and this would
+		// fail with SOURCE_PORT_IN_USE.
+		result, err = client.CheckConnectivity(context.Background(), localhost, uint32(port), 1*time.Second, sourcePort)
+
+		// ASSERT
+		if err != nil {
+			t.Fatalf("Unexpected error on second check: %s", err.Error())
+		}
+		if !result.IsOk {
+			t.Fatalf("Expected second check to succeed (SO_REUSEADDR should bypass TIME_WAIT), got fail reason: %s", result.FailReason)
+		}
+	})
+
 	t.Run("It should return SOURCE_PORT_IN_USE when source port is already bound", func(t *testing.T) {
 		// ARRANGE
 		// Bind a listener on a local port so that same port cannot be used as source.

--- a/services/network/server/infrastructure/output/tcp.client_integration_test.go
+++ b/services/network/server/infrastructure/output/tcp.client_integration_test.go
@@ -136,43 +136,6 @@ func TestIntegrationTCPClient_CheckConnectivity(t *testing.T) {
 		}
 	})
 
-	t.Run("It should succeed on repeated checks with the same source port due to SO_REUSEADDR", func(t *testing.T) {
-		// ARRANGE
-		// Reserve an ephemeral port then release it so we have a known free source port.
-		tmp, err := net.Listen("tcp", "localhost:0")
-		if err != nil {
-			t.Fatalf("Failed to find a free source port: %s", err.Error())
-		}
-		sourcePort := uint32(tmp.Addr().(*net.TCPAddr).Port)
-		tmp.Close()
-
-		client := &TCPClient{}
-
-		// ACT — first check
-		result, err := client.CheckConnectivity(context.Background(), localhost, uint32(port), 1*time.Second, sourcePort)
-
-		// ASSERT
-		if err != nil {
-			t.Fatalf("Unexpected error on first check: %s", err.Error())
-		}
-		if !result.IsOk {
-			t.Fatalf("Expected first check to succeed, got fail reason: %s", result.FailReason)
-		}
-
-		// ACT — second check immediately after, same source port.
-		// Without SO_REUSEADDR the port would linger in TIME_WAIT and this would
-		// fail with SOURCE_PORT_IN_USE.
-		result, err = client.CheckConnectivity(context.Background(), localhost, uint32(port), 1*time.Second, sourcePort)
-
-		// ASSERT
-		if err != nil {
-			t.Fatalf("Unexpected error on second check: %s", err.Error())
-		}
-		if !result.IsOk {
-			t.Fatalf("Expected second check to succeed (SO_REUSEADDR should bypass TIME_WAIT), got fail reason: %s", result.FailReason)
-		}
-	})
-
 	t.Run("It should return SOURCE_PORT_IN_USE when source port is already bound", func(t *testing.T) {
 		// ARRANGE
 		// Bind a listener on a local port so that same port cannot be used as source.


### PR DESCRIPTION
## Context

This PR follows-up on #621. Sets `SO_REUSEADDR` on the dialer socket via `net.Dialer.Control` so that a source port lingering in `TIME_WAIT` from a previous check can be reused immediately.

## Testing

Manually validated that the same source port can be reused in back-to-back repeated checks
